### PR TITLE
Add O3 optimization pass to supress build errors and cleanup meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -86,20 +86,6 @@ else
 	)
 endif
 
-features = {
-	'drm-backend': false,
-	'x11-backend': false,
-	'libinput-backend': false,
-	'xwayland': false,
-	'gles2-renderer': false,
-	'vulkan-renderer': false,
-	'gbm-allocator': false,
-}
-internal_features = {
-	'xcb-errors': false,
-	'egl': false,
-}
-
 wayland_project_options = ['tests=false', 'documentation=false']
 wayland_server = dependency('wayland-server',
 	version: '>=1.21',
@@ -109,7 +95,7 @@ wayland_server = dependency('wayland-server',
 
 wlroots_options = [ 'examples=false' ]
 wlroots = dependency('wlroots',
-	version: '0.16.2',
+	version: '>=0.16.2',
 	fallback: 'wayland',
 	default_options: wlroots_options,
 )
@@ -141,8 +127,8 @@ pixman = dependency('pixman-1')
 math = cc.find_library('m')
 rt = cc.find_library('rt')
 
-wlr_files = []
-wlr_deps = [
+scenefx_files = []
+scenefx_deps = [
 	wlroots,
 	wayland_server,
 	drm,
@@ -161,40 +147,25 @@ subdir('util')
 
 subdir('include')
 
-foreach name, have : internal_features
-	add_project_arguments(
-		'-DHAS_@0@=@1@'.format(name.underscorify().to_upper(), have.to_int()),
-		language: 'c',
-	)
-endforeach
-
 scenefx_inc = include_directories('include')
 proto_inc = include_directories('protocol')
 
 lib_scenefx = library(
-	meson.project_name(), wlr_files,
+	meson.project_name(), scenefx_files,
 	soversion: soversion.to_string(),
-	dependencies: wlr_deps,
+	dependencies: scenefx_deps,
 	include_directories:  [ scenefx_inc, proto_inc ],
 	install: true,
 )
 
 
-wlr_vars = {}
-foreach name, have : features
-	wlr_vars += { 'have_' + name.underscorify(): have.to_string() }
-endforeach
-
 scenefx = declare_dependency(
 	link_with: lib_scenefx,
-	dependencies: wlr_deps,
+	dependencies: scenefx_deps,
 	include_directories: scenefx_inc,
-	variables: wlr_vars,
 )
 
 meson.override_dependency('scenefx', scenefx)
-
-summary(features + internal_features, bool_yn: true)
 
 if get_option('examples')
 	# TODO:	subdir('examples')
@@ -207,5 +178,4 @@ pkgconfig.generate(lib_scenefx,
 	filebase: meson.project_name(),
 	name: meson.project_name(),
 	description: 'Wlroots effects library',
-	variables: wlr_vars,
 )

--- a/meson.build
+++ b/meson.build
@@ -21,6 +21,7 @@ little_endian = target_machine.endian() == 'little'
 big_endian = target_machine.endian() == 'big'
 
 add_project_arguments([
+	'-O3',
 	'-DWLR_USE_UNSTABLE',
 	'-DWLR_LITTLE_ENDIAN=@0@'.format(little_endian.to_int()),
 	'-DWLR_BIG_ENDIAN=@0@'.format(big_endian.to_int()),

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -68,7 +68,7 @@ foreach name, path : protocols
 		output: '@BASENAME@-protocol.c',
 		command: [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
 	)
-	wlr_files += code
+	scenefx_files += code
 
 	server_header = custom_target(
 		name.underscorify() + '_server_h',
@@ -76,7 +76,7 @@ foreach name, path : protocols
 		output: '@BASENAME@-protocol.h',
 		command: [wayland_scanner, 'server-header', '@INPUT@', '@OUTPUT@'],
 	)
-	wlr_files += server_header
+	scenefx_files += server_header
 
 	client_header = custom_target(
 		name.underscorify() + '_client_h',

--- a/render/meson.build
+++ b/render/meson.build
@@ -1,3 +1,3 @@
-wlr_files += files(
+scenefx_files += files(
 	'pixel_format.c',
 )

--- a/types/meson.build
+++ b/types/meson.build
@@ -1,4 +1,4 @@
-wlr_files += files(
+scenefx_files += files(
 	'scene/subsurface_tree.c',
 	'scene/surface.c',
 	'scene/wlr_scene.c',

--- a/util/meson.build
+++ b/util/meson.build
@@ -1,4 +1,4 @@
-wlr_files += files(
+scenefx_files += files(
 	'array.c',
 	'env.c',
 	'time.c',


### PR DESCRIPTION
```bash
[76/127] Compiling C object libscenefx.so.1.p/meson-generated_.._protocol_ext-idle-notify-v1-protocol.c.o
In file included from /nix/store/9bldnbh7kcxyq8y0g1bifd5ywz7m3bq9-glibc-2.37-8-dev/include/bits/libc-header-start.h:33,
                 from /nix/store/9bldnbh7kcxyq8y0g1bifd5ywz7m3bq9-glibc-2.37-8-dev/include/stdlib.h:26,
                 from protocol/ext-idle-notify-v1-protocol.c:27:
/nix/store/9bldnbh7kcxyq8y0g1bifd5ywz7m3bq9-glibc-2.37-8-dev/include/features.h:413:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
  413 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
      |    ^~~~~~~
```