### PR TITLE
Tinywl: stop asserting that all surfaces are xdg_surfaces

### DIFF
--- a/tinywl/tinywl.c
+++ b/tinywl/tinywl.c
@@ -613,8 +613,14 @@ static void output_configure_scene(struct wlr_scene_node *node,
 
 		struct wlr_scene_surface * scene_surface
 			= wlr_scene_surface_from_buffer(buffer);
-		struct wlr_xdg_surface *xdg_surface =
-			wlr_xdg_surface_from_wlr_surface(scene_surface->surface);
+		if (!scene_surface) {
+			return;
+		}
+
+		struct wlr_xdg_surface *xdg_surface = NULL;
+		if (wlr_surface_is_xdg_surface(scene_surface->surface)) {
+			xdg_surface = wlr_xdg_surface_from_wlr_surface(scene_surface->surface);
+		}
 
 		if (xdg_surface &&
 				xdg_surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL) {


### PR DESCRIPTION
Fixes a segfault caused by #10 