### PR TITLE
feat: complete nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,28 +1,12 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709905912,
-        "narHash": "sha256-TofHtnlrOBCxtSZ9nnlsTybDnQXUmQrlIleXF1RQAwQ=",
+        "lastModified": 1713128889,
+        "narHash": "sha256-aB90ZqzosyRDpBh+rILIcyP5lao8SKz8Sr2PSWvZrzk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a343533bccc62400e8a9560423486a3b6c11a23b",
+        "rev": "2748d22b45a99fb2deafa5f11c7531c212b2cefa",
         "type": "github"
       },
       "original": {
@@ -34,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -66,21 +66,15 @@
       devShells = forEachSystem (pkgs: {
         default = pkgs.mkShell {
           name = "scenefx-shell";
-
           inputsFrom = [
             self.packages.${pkgs.system}.scenefx
             pkgs.wlroots_0_17
           ];
-
-          nativeBuildInputs = [
-            pkgs.hwdata # for wlroots
-          ];
-
-          shellHook = with pkgs; ''
+          shellHook = ''
             (
-              mkdir -p "$PWD/subprojects"
-              cd "$PWD/subprojects"
-              cp -R --no-preserve=mode,ownership ${wlroots_0_17.src} wlroots
+              # Copy the nix version of wlroots into the project
+              mkdir -p "$PWD/subprojects" && cd "$PWD/subprojects"
+              cp -R --no-preserve=mode,ownership ${pkgs.wlroots_0_17.src} wlroots
             )'';
         };
       });

--- a/flake.nix
+++ b/flake.nix
@@ -1,49 +1,90 @@
 {
-  description = "scenefx development environment";
-
-  inputs = {
-    flake-compat = {
-      url = "github:edolstra/flake-compat";
-      flake = false;
-    };
-
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-  };
-
-  outputs = { self, nixpkgs, flake-compat, ... }:
+  description = "Scenefx development environment";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  outputs =
+    { self, nixpkgs, ... }:
     let
-      pkgsFor = system:
-        import nixpkgs {
-          inherit system;
-          overlays = [ ];
-        };
-
-      targetSystems = [ "aarch64-linux" "x86_64-linux" ];
-    in {
-      devShells = nixpkgs.lib.genAttrs targetSystems (system:
-        let pkgs = pkgsFor system;
-        in {
-          default = pkgs.mkShell {
-            name = "scenefx-shell";
-
-            inputsFrom = [ pkgs.wlroots_0_17 ];
-
-            nativeBuildInputs = with pkgs; [
-              cmake
-              meson
-              ninja
-              scdoc
-              pkg-config
-              hwdata
+      mkPackages = pkgs: {
+        scenefx = pkgs.callPackage (
+          { wlroots_0_17, ... }:
+          pkgs.stdenv.mkDerivation {
+            pname = "scenefx";
+            version = "0.1.0-git";
+            src = ./.;
+            outputs = [
+              "out"
+              "lib"
             ];
 
-            shellHook = with pkgs; ''(
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+              meson
+              cmake
+              ninja
+              scdoc
+            ];
+
+            buildInputs = with pkgs; [
+              libdrm
+              libxkbcommon
+              pixman
+              libGL # egl
+              mesa # gbm
+              wayland # wayland-server
+              wayland-protocols
+              wlroots_0_17
+            ];
+
+            meta = with pkgs.lib; {
+              description = "A drop-in replacement for the wlroots scene API that allows wayland compositors to render surfaces with eye-candy effects";
+              homepage = "https://github.com/wlrfx/scenefx";
+              license = licenses.mit;
+              platforms = platforms.linux;
+            };
+          }
+        ) { };
+      };
+
+      targetSystems = [
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+      pkgsFor = system: import nixpkgs { inherit system; };
+      forEachSystem = f: nixpkgs.lib.genAttrs targetSystems (system: f (pkgsFor system));
+    in
+    {
+      overlays = rec {
+        default = insert;
+        override = _: prev: mkPackages prev;
+        insert = _: prev: mkPackages (pkgsFor prev.system);
+      };
+
+      packages = forEachSystem (
+        pkgs: (mkPackages pkgs) // { default = self.packages.${pkgs.system}.scenefx; }
+      );
+
+      devShells = forEachSystem (pkgs: {
+        default = pkgs.mkShell {
+          name = "scenefx-shell";
+
+          inputsFrom = [
+            self.packages.${pkgs.system}.scenefx
+            pkgs.wlroots_0_17
+          ];
+
+          nativeBuildInputs = [
+            pkgs.hwdata # for wlroots
+          ];
+
+          shellHook = with pkgs; ''
+            (
               mkdir -p "$PWD/subprojects"
               cd "$PWD/subprojects"
               cp -R --no-preserve=mode,ownership ${wlroots_0_17.src} wlroots
             )'';
-          };
-        });
+        };
+      });
+
+      formatter = forEachSystem (pkgs: pkgs.nixfmt-rfc-style);
     };
 }
-


### PR DESCRIPTION
## Summary

Refactor the nix flake to a complete version, following the same principles of the recent swayfx flake overhaul.

### Outputs

#### Packages

Output a default and scenefx package, which provides `out` and `lib` outputs (compatible with pkg-config)

#### Overlays

Provides both an insert and override overlay, one that will work with any nixpkgs and just insert the locked package as is, or the more advanced override that must be used with a smiliar nixpkgs unstable version, which can be used to overlay additional things etc.

---

> [Passing Garnix CI](https://github.com/ozwaldorf/scenefx/runs/23842110722)