### PR TITLE
Fix: blur effects

### DIFF
--- a/render/fx_renderer/gles2/shaders/blur_effects.frag
+++ b/render/fx_renderer/gles2/shaders/blur_effects.frag
@@ -51,7 +51,9 @@ float hash(vec2 p) {
 
 void main() {
 	vec4 color = texture2D(tex, v_texcoord);
-	color *= brightnessMatrix() * contrastMatrix() * saturationMatrix();
+	// Do *not* transpose the combined matrix when multiplying
+	color = brightnessMatrix() * contrastMatrix() * saturationMatrix() * color;
+
 	float noiseHash = hash(v_texcoord);
 	float noiseAmount = (mod(noiseHash, 1.0) - 0.5);
 	color.rgb += noiseAmount * noise;

--- a/render/fx_renderer/gles2/shaders/blur_effects.frag
+++ b/render/fx_renderer/gles2/shaders/blur_effects.frag
@@ -30,14 +30,13 @@ mat4 contrastMatrix() {
 }
 
 mat4 saturationMatrix() {
-	vec3 luminance = vec3(0.3086, 0.6094, 0.0820);
-	float oneMinusSat = 1.0 - saturation;
-	vec3 red = vec3(luminance.x * oneMinusSat);
-	red+= vec3(saturation, 0, 0);
-	vec3 green = vec3(luminance.y * oneMinusSat);
-	green += vec3(0, saturation, 0);
-	vec3 blue = vec3(luminance.z * oneMinusSat);
-	blue += vec3(0, 0, saturation);
+	vec3 luminance = vec3(0.3086, 0.6094, 0.0820) * (1.0 - saturation);
+	vec3 red = vec3(luminance.x);
+	red.x += saturation;
+	vec3 green = vec3(luminance.y);
+	green.y += saturation;
+	vec3 blue = vec3(luminance.z);
+	blue.z += saturation;
 	return mat4(red, 0,
 				green, 0,
 				blue, 0,

--- a/render/fx_renderer/gles2/shaders/blur_effects.frag
+++ b/render/fx_renderer/gles2/shaders/blur_effects.frag
@@ -1,17 +1,13 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
-#else
-precision mediump float;
-#endif
 
 varying vec2 v_texcoord;
 
 uniform sampler2D tex;
 
-uniform float noise;
 uniform float brightness;
 uniform float contrast;
 uniform float saturation;
+uniform float noise;
 
 mat4 brightnessMatrix() {
 	float b = brightness - 1.0;
@@ -43,19 +39,17 @@ mat4 saturationMatrix() {
 				0, 0, 0, 1);
 }
 
-// Fast generative noise function
-float hash(vec2 p) {
-	return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
-}
+float noiseAmount(vec2 p) {
+	vec3 p3 = fract(vec3(p.xyx) * 1689.1984);
+	p3 += dot(p3, p3.yzx + 33.33);
+	float hash = fract((p3.x + p3.y) * p3.z);
+	return (mod(hash, 1.0) - 0.5) * noise;
+};
 
 void main() {
 	vec4 color = texture2D(tex, v_texcoord);
 	// Do *not* transpose the combined matrix when multiplying
 	color = brightnessMatrix() * contrastMatrix() * saturationMatrix() * color;
-
-	float noiseHash = hash(v_texcoord);
-	float noiseAmount = (mod(noiseHash, 1.0) - 0.5);
-	color.rgb += noiseAmount * noise;
-
+	color.xyz += noiseAmount(v_texcoord);
 	gl_FragColor = color;
 }


### PR DESCRIPTION
## Summary

- The combined transform matrix is currently transposed when multiplying against the color, resulting in some odd color shifts when using saturation. Fixed and left an explicit comment for the next person
- The current rng/noise function used has some issues on nvidia resulting in some line artifacts with higher noise values. Replaced with a new function used by hyprland in https://github.com/hyprwm/Hyprland/pull/5607. Note that the conditional for float precision is removed and always set to high due to nvidia not working correctly on medium precision.
- Be consistent in the ordering of [brightness, contrast, saturation, noise]

## Related issues

Fixes #41 