### PR TITLE
fix: add wayland-scanner to native build dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
               cmake
               ninja
               scdoc
+              wayland-scanner
             ];
 
             buildInputs = with pkgs; [


### PR DESCRIPTION
Build is broken on unstable nixpkgs after NixOS/nixpkgs#214906 has been merged. `wayland-scanner` is a different package now and it needs to be explicitly added to the native build dependencies.