### PR TITLE
fix: corner rounding logic when corners overlap

### DIFF
--- a/render/fx_renderer/gles2/shaders/corner_alpha.frag
+++ b/render/fx_renderer/gles2/shaders/corner_alpha.frag
@@ -1,23 +1,13 @@
-float roundRectSDF(vec2 half_size, vec2 position, float radius);
-
 float corner_alpha(vec2 size, vec2 position, float radius,
             bool round_tl, bool round_tr, bool round_bl, bool round_br) {
 	vec2 relative_pos = (gl_FragCoord.xy - position);
 
-	// Brachless baby!
-	// Selectively round individual corners
-	float top = step(relative_pos.y - radius, 0.0);
-	float left = step(relative_pos.x - radius, 0.0);
-	float right = step(size.x - radius, relative_pos.x);
-	float bottom = step(size.y - radius, relative_pos.y);
+	vec2 top_left = float(round_tl) * abs(relative_pos - size) - size + radius;
+	vec2 top_right = float(round_tr) * abs(relative_pos - vec2(0, size.y)) - size + radius;
+	vec2 bottom_left = float(round_br) * abs(relative_pos - vec2(size.x, 0)) - size + radius;
+	vec2 bottom_right = float(round_bl) * abs(relative_pos) - size + radius;
 
-	float top_left = top * left * float(round_tl);
-	float top_right = top * right * float(round_tr);
-	float bottom_left = bottom * left * float(round_bl);
-	float bottom_right = bottom * right * float(round_br);
-	// A value of 1 means that we're allowed to round at this position
-	float round_corners = top_left + top_right + bottom_left + bottom_right;
+	vec2 q = max(max(top_left, top_right), max(bottom_left, bottom_right));
 
-	float alpha = smoothstep(-1.0, 1.0, roundRectSDF(size * 0.5, position, radius));
-	return alpha * round_corners;
+	return smoothstep(-1.0, 1.0, min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - radius);
 }

--- a/render/fx_renderer/gles2/shaders/quad_round.frag
+++ b/render/fx_renderer/gles2/shaders/quad_round.frag
@@ -18,10 +18,12 @@ uniform bool round_bottom_right;
 float corner_alpha(vec2 size, vec2 position, float radius,
             bool round_tl, bool round_tr, bool round_bl, bool round_br);
 
+float roundRectSDF(vec2 half_size, vec2 position, float radius);
+
 void main() {
     float corner_alpha = corner_alpha(size, position, radius,
             round_top_left, round_top_right, round_bottom_left, round_bottom_right);
-    float window_alpha = 1.0; // TODO: smoothstep(-1.0, 1.0, roundRectSDF(window_half_size, window_position, window_radius + 1.0)); // pull in radius by 1.0 px
+    float window_alpha = smoothstep(-1.0, 1.0, roundRectSDF(window_half_size, window_position, window_radius + 1.0)); // pull in radius by 1.0 px
 
     gl_FragColor = mix(v_color, vec4(0.0), corner_alpha) * window_alpha;
 }

--- a/render/fx_renderer/gles2/shaders/tex.frag
+++ b/render/fx_renderer/gles2/shaders/tex.frag
@@ -50,16 +50,12 @@ float corner_alpha(vec2 size, vec2 position, float radius,
             bool round_tl, bool round_tr, bool round_bl, bool round_br);
 
 void main() {
-	gl_FragColor = mix(sample_texture(), dim_color, dim) * alpha;
+	float corner_alpha = corner_alpha(size, position, radius,
+			round_top_left, round_top_right, round_bottom_left, round_bottom_right);
+	gl_FragColor = mix(mix(sample_texture(), dim_color, dim) * alpha, vec4(0.0), corner_alpha);
 
 	if (discard_transparent && gl_FragColor.a == 0.0) {
 		discard;
 		return;
-	}
-
-	if (round_top_left || round_top_right || round_bottom_left || round_bottom_right) {
-		float corner_alpha = corner_alpha(size, position, radius,
-				round_top_left, round_top_right, round_bottom_left, round_bottom_right);
-		gl_FragColor = mix(gl_FragColor, vec4(0.0), corner_alpha);
 	}
 }

--- a/render/fx_renderer/shaders.c
+++ b/render/fx_renderer/shaders.c
@@ -213,8 +213,8 @@ bool link_quad_grad_round_program(struct quad_grad_round_shader *shader, int max
 
 bool link_tex_program(struct tex_shader *shader, enum fx_tex_shader_source source) {
 	GLchar frag_src[4096];
-	snprintf(frag_src, sizeof(frag_src), "#define SOURCE %d\n%s\n%s\n%s", source,
-			tex_frag_src, corner_alpha_frag_src, round_rect_sdf_frag_src);
+	snprintf(frag_src, sizeof(frag_src), "#define SOURCE %d\n%s\n%s\n", source,
+			tex_frag_src, corner_alpha_frag_src);
 
 	GLuint prog;
 	shader->program = prog = link_program(frag_src);


### PR DESCRIPTION
The current corner rounding logic has a bug: if the rect is small enough that any individual corners overlap, the overlapping corners are both rendered, regardless of it should just render the top left / top right / bottom left / bottom right. As an example:
![2025-01-10_18-01-1736552970](https://github.com/user-attachments/assets/6f99a89d-a885-469d-b395-50fdf4596820)

This PR fixes this behaviour (and also adds back inner corners to the rect shader)