### PR TITLE
Add accepts_input bool to scene rect

### DIFF
--- a/include/scenefx/types/wlr_scene.h
+++ b/include/scenefx/types/wlr_scene.h
@@ -145,6 +145,8 @@ struct wlr_scene_rect {
 	float color[4];
 	int corner_radius;
 	enum corner_location corners;
+
+	bool accepts_input;
 };
 
 /** A scene-graph node displaying a shadow */

--- a/types/scene/wlr_scene.c
+++ b/types/scene/wlr_scene.c
@@ -666,6 +666,7 @@ struct wlr_scene_rect *wlr_scene_rect_create(struct wlr_scene_tree *parent,
 	memcpy(scene_rect->color, color, sizeof(scene_rect->color));
 	scene_rect->corner_radius = 0;
 	scene_rect->corners = CORNER_LOCATION_NONE;
+	scene_rect->accepts_input = false;
 
 	scene_node_update(&scene_rect->node, NULL);
 
@@ -1427,6 +1428,11 @@ static bool scene_node_at_iterator(struct wlr_scene_node *node,
 
 		if (scene_buffer->point_accepts_input &&
 				!scene_buffer->point_accepts_input(scene_buffer, &rx, &ry)) {
+			return false;
+		}
+	} else if (node->type == WLR_SCENE_NODE_RECT) {
+		struct wlr_scene_rect *rect = wlr_scene_rect_from_node(node);
+		if (rect->accepts_input) {
 			return false;
 		}
 	} else if (node->type == WLR_SCENE_NODE_SHADOW

--- a/types/scene/wlr_scene.c
+++ b/types/scene/wlr_scene.c
@@ -666,7 +666,7 @@ struct wlr_scene_rect *wlr_scene_rect_create(struct wlr_scene_tree *parent,
 	memcpy(scene_rect->color, color, sizeof(scene_rect->color));
 	scene_rect->corner_radius = 0;
 	scene_rect->corners = CORNER_LOCATION_NONE;
-	scene_rect->accepts_input = false;
+	scene_rect->accepts_input = true;
 
 	scene_node_update(&scene_rect->node, NULL);
 
@@ -1432,7 +1432,7 @@ static bool scene_node_at_iterator(struct wlr_scene_node *node,
 		}
 	} else if (node->type == WLR_SCENE_NODE_RECT) {
 		struct wlr_scene_rect *rect = wlr_scene_rect_from_node(node);
-		if (rect->accepts_input) {
+		if (!rect->accepts_input) {
 			return false;
 		}
 	} else if (node->type == WLR_SCENE_NODE_SHADOW


### PR DESCRIPTION
This allows compositors to exclude rects when running the `wlr_scene_node_at` function.

Needed for the swayfx dim effect