### PR TITLE
Apply the output transform to all corner_location uses

### DIFF
--- a/include/scenefx/render/pass.h
+++ b/include/scenefx/render/pass.h
@@ -71,7 +71,6 @@ struct fx_render_rect_grad_options {
 struct fx_render_rounded_rect_options {
 	struct wlr_render_rect_options base;
 	int corner_radius;
-	enum wl_output_transform transform;
 	enum corner_location corners;
 
 	struct clipped_region clipped_region;
@@ -81,7 +80,6 @@ struct fx_render_rounded_rect_grad_options {
 	struct wlr_render_rect_options base;
 	struct fx_gradient gradient;
 	int corner_radius;
-	enum wl_output_transform transform;
 	enum corner_location corners;
 };
 

--- a/include/scenefx/render/pass.h
+++ b/include/scenefx/render/pass.h
@@ -71,6 +71,7 @@ struct fx_render_rect_grad_options {
 struct fx_render_rounded_rect_options {
 	struct wlr_render_rect_options base;
 	int corner_radius;
+	enum wl_output_transform transform;
 	enum corner_location corners;
 
 	struct clipped_region clipped_region;
@@ -80,6 +81,7 @@ struct fx_render_rounded_rect_grad_options {
 	struct wlr_render_rect_options base;
 	struct fx_gradient gradient;
 	int corner_radius;
+	enum wl_output_transform transform;
 	enum corner_location corners;
 };
 

--- a/render/fx_renderer/fx_pass.c
+++ b/render/fx_renderer/fx_pass.c
@@ -310,7 +310,6 @@ void fx_render_pass_add_texture(struct fx_gles_render_pass *pass,
 	}
 
 	enum corner_location corners = fx_options->corners;
-	corner_location_transform(fx_options->base.transform, &corners);
 
 	glUniform1i(shader->tex, 0);
 	glUniform1f(shader->alpha, alpha);

--- a/render/fx_renderer/gles2/shaders/corner_alpha.frag
+++ b/render/fx_renderer/gles2/shaders/corner_alpha.frag
@@ -1,13 +1,21 @@
+// TODO: surely I can be optimized
 float corner_alpha(vec2 size, vec2 position, float radius,
             bool round_tl, bool round_tr, bool round_bl, bool round_br) {
 	vec2 relative_pos = (gl_FragCoord.xy - position);
 
-	vec2 top_left = float(round_tl) * abs(relative_pos - size) - size + radius;
-	vec2 top_right = float(round_tr) * abs(relative_pos - vec2(0, size.y)) - size + radius;
-	vec2 bottom_left = float(round_br) * abs(relative_pos - vec2(size.x, 0)) - size + radius;
-	vec2 bottom_right = float(round_bl) * abs(relative_pos) - size + radius;
+	vec2 top_left = abs(relative_pos - size) - size + radius;
+	vec2 top_right = abs(relative_pos - vec2(0, size.y)) - size + radius;
+	vec2 bottom_left = abs(relative_pos - vec2(size.x, 0)) - size + radius;
+	vec2 bottom_right = abs(relative_pos) - size + radius;
 
-	vec2 q = max(max(top_left, top_right), max(bottom_left, bottom_right));
-
-	return smoothstep(-1.0, 1.0, min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - radius);
+	return max(
+		max(
+			float(round_tl) * smoothstep(-1.0, 1.0, min(max(top_left.x, top_left.y), 0.0) + length(max(top_left, 0.0)) - radius),
+			float(round_tr) * smoothstep(-1.0, 1.0, min(max(top_right.x, top_right.y), 0.0) + length(max(top_right, 0.0)) - radius)
+		),
+		max(
+			float(round_bl) * smoothstep(-1.0, 1.0, min(max(bottom_left.x, bottom_left.y), 0.0) + length(max(bottom_left, 0.0)) - radius),
+			float(round_br) * smoothstep(-1.0, 1.0, min(max(bottom_right.x, bottom_right.y), 0.0) + length(max(bottom_right, 0.0)) - radius)
+		)
+    );
 }


### PR DESCRIPTION
The corner location transform function wasn't called for each use in the past, which caused the corners to not compensate for eventual output rotation.

TODO:
- [x] Call `corner_location_transform` before each use
- [x] Fix the `corner_alpha.frag` shader