### PR TITLE
Decoration clipping adjustments

### DIFF
--- a/render/fx_renderer/fx_pass.c
+++ b/render/fx_renderer/fx_pass.c
@@ -609,6 +609,7 @@ void fx_render_pass_add_box_shadow(struct fx_gles_render_pass *pass,
 	glUniform1f(renderer->shaders.box_shadow.blur_sigma, options->blur_sigma);
 	glUniform2f(renderer->shaders.box_shadow.size, box.width, box.height);
 	glUniform2f(renderer->shaders.box_shadow.position, box.x, box.y);
+	glUniform1f(renderer->shaders.box_shadow.corner_radius, options->corner_radius);
 
 	glUniform1f(renderer->shaders.box_shadow.clip_radius_top_left,
 			(CORNER_LOCATION_TOP_LEFT & clipped_region_corners) == CORNER_LOCATION_TOP_LEFT ?
@@ -624,6 +625,7 @@ void fx_render_pass_add_box_shadow(struct fx_gles_render_pass *pass,
 			clipped_region_corner_radius : 0);
 
 	glUniform2f(renderer->shaders.box_shadow.clip_position, clipped_region_box.x, clipped_region_box.y);
+	glUniform2f(renderer->shaders.box_shadow.clip_size, clipped_region_box.width, clipped_region_box.height);
 
 	render(&box, &clip_region, renderer->shaders.box_shadow.pos_attrib);
 	pixman_region32_fini(&clip_region);

--- a/render/fx_renderer/gles2/shaders/box_shadow.frag
+++ b/render/fx_renderer/gles2/shaders/box_shadow.frag
@@ -84,8 +84,8 @@ void main() {
 
     // Clipping
     float clip_corner_alpha = corner_alpha(
-        clip_size - 1.0,
-        clip_position + 0.5,
+        clip_size - 1.5,
+        clip_position + 0.75,
         clip_radius_top_left,
         clip_radius_top_right,
         clip_radius_bottom_left,

--- a/render/fx_renderer/gles2/shaders/quad_grad_round.frag
+++ b/render/fx_renderer/gles2/shaders/quad_grad_round.frag
@@ -26,8 +26,8 @@ float corner_alpha(vec2 size, vec2 position, float round_tl, float round_tr, flo
 // TODO:
 void main() {
     float quad_corner_alpha = corner_alpha(
-        size,
-        position,
+        size - 1.0,
+        position + 0.5,
         radius_top_left,
         radius_top_right,
         radius_bottom_left,

--- a/render/fx_renderer/gles2/shaders/quad_round.frag
+++ b/render/fx_renderer/gles2/shaders/quad_round.frag
@@ -20,8 +20,8 @@ float corner_alpha(vec2 size, vec2 position, float round_tl, float round_tr, flo
 
 void main() {
     float quad_corner_alpha = corner_alpha(
-        size,
-        position,
+        size - 1.0,
+        position + 0.5,
         radius_top_left,
         radius_top_right,
         radius_bottom_left,

--- a/render/fx_renderer/gles2/shaders/tex.frag
+++ b/render/fx_renderer/gles2/shaders/tex.frag
@@ -47,8 +47,8 @@ float corner_alpha(vec2 size, vec2 position, float round_tl, float round_tr, flo
 
 void main() {
     float corner_alpha = corner_alpha(
-        size,
-        position,
+        size - 0.5,
+        position + 0.25,
         radius_top_left,
         radius_top_right,
         radius_bottom_left,


### PR DESCRIPTION
These are some small shader adjustments to make rounded corners look a little more natural.

- Outside clipping for the tex shader is pulled in by 0.25px to minimize overlap with borders, and for slightly smoother antialiasing.
- Outside clipping for rounded quads is pulled in by 0.5px to match the inside and keep the width consistent on the corners.
- Inside clipping for box shadows is pulled in by 0.75px to remove gaps between it and the borders.

There is also a fix in `fx_pass.c` to make box shadows use their corner radius and clip to the border properly.

Corners before and after:
![corner-before](https://github.com/user-attachments/assets/c03b7950-38c1-41dd-81bf-324d5ad579a0) ![corner-after](https://github.com/user-attachments/assets/aacd47a0-73ea-4b29-ab44-fa2fad7eb847)

Shadows before and after (transparent 10px border so the shadow is visible behind it):

![shadow-before](https://github.com/user-attachments/assets/aa37ed6d-c16e-4e92-a270-977976f3265e) ![shadow-after](https://github.com/user-attachments/assets/251d30c7-a19d-4b27-9fba-b3436f604234)

