### PR TITLE
Add optional Tracy support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-/subprojects/
+subprojects/*
 build/
 .cache/
 result
+
+!subprojects/tracy.wrap

--- a/include/render/fx_renderer/fx_renderer.h
+++ b/include/render/fx_renderer/fx_renderer.h
@@ -194,6 +194,10 @@ struct fx_renderer {
 	// Set to true when 'wlr_renderer_begin_buffer_pass' is called instead of
 	// our custom 'fx_renderer_begin_buffer_pass' function
 	bool basic_renderer;
+
+	GLint client_version;
+
+	struct tracy_data *tracy_data;
 };
 
 #endif

--- a/include/render/tracy.h
+++ b/include/render/tracy.h
@@ -1,0 +1,80 @@
+#ifndef TRACY
+#define TRACY
+
+#include "include/render/fx_renderer/fx_renderer.h"
+
+struct tracy_data;
+struct tracy_gpu_ctx {
+	struct tracy_data *tracy_data;
+	bool is_active;
+};
+
+#ifdef TRACY_ENABLE
+#include <tracy/TracyC.h>
+
+#define TRACY_MARK_FRAME_START(name) TracyCFrameMarkStart(name)
+#define TRACY_MARK_FRAME_END(name) TracyCFrameMarkEnd(name)
+
+#define TRACY_ZONE_START \
+	TracyCZoneS(ctx, 10, true)
+#define TRACY_ZONE_END \
+	TracyCZoneEnd(ctx)
+#define TRACY_ZONE_VALUE(value) \
+	TracyCZoneValue(ctx, value);
+
+#define TRACY_GPU_ZONE_START_NAME(renderer, name) \
+	struct tracy_gpu_ctx gpu_ctx; \
+	tracy_gpu_zone_begin(renderer->tracy_data, &gpu_ctx, __LINE__, __FILE__, __func__, name)
+#define TRACY_GPU_ZONE_START(renderer) \
+	struct tracy_gpu_ctx gpu_ctx; \
+	tracy_gpu_zone_begin(renderer->tracy_data, &gpu_ctx, __LINE__, __FILE__, __func__, __func__)
+#define TRACY_GPU_ZONE_END \
+	tracy_gpu_zone_end(&gpu_ctx)
+#define TRACY_GPU_ZONE_COLLECT(renderer) \
+	tracy_gpu_context_collect(renderer->tracy_data)
+
+#define TRACY_GPU_CONTEXT_NEW(renderer) \
+	tracy_gpu_context_new(renderer)
+#define TRACY_GPU_CONTEXT_DESTROY(tracy_data) \
+	tracy_gpu_context_destroy(tracy_data);
+
+#define TRACY_BOTH_ZONES_START(renderer) \
+	TRACY_ZONE_START \
+	TRACY_GPU_ZONE_START(renderer)
+#define TRACY_BOTH_ZONES_END \
+	TRACY_ZONE_END \
+	TRACY_GPU_ZONE_END
+
+// Private functions: Don't use these outside of this file!
+
+void tracy_gpu_zone_begin(struct tracy_data *tracy_data, struct tracy_gpu_ctx *out_ctx,
+		const int line, const char *source, const char *func, const char *name);
+void tracy_gpu_zone_end(struct tracy_gpu_ctx *ctx);
+
+void tracy_gpu_context_collect(struct tracy_data *tracy_data);
+void tracy_gpu_context_destroy(struct tracy_data *tracy_data);
+struct tracy_data *tracy_gpu_context_new(struct fx_renderer *renderer);
+
+#else
+
+#define TRACY_MARK_FRAME_START(name)
+#define TRACY_MARK_FRAME_END(name)
+
+#define TRACY_ZONE_START
+#define TRACY_ZONE_END
+#define TRACY_ZONE_VALUE(value)
+
+#define TRACY_GPU_ZONE_START_NAME(renderer, name)
+#define TRACY_GPU_ZONE_START(renderer)
+#define TRACY_GPU_ZONE_END
+#define TRACY_GPU_ZONE_COLLECT(renderer)
+
+#define TRACY_GPU_CONTEXT_NEW(renderer) NULL
+#define TRACY_GPU_CONTEXT_DESTROY(tracy_data)
+
+#define TRACY_BOTH_ZONES_START(renderer)
+#define TRACY_BOTH_ZONES_END
+
+#endif  /* ifdef TRACY_ENABLE */
+
+#endif  // !TRACY

--- a/meson.build
+++ b/meson.build
@@ -112,6 +112,7 @@ pixman = dependency('pixman-1',
 math = cc.find_library('m')
 rt = cc.find_library('rt')
 
+scenefx_override_options = []
 scenefx_files = []
 scenefx_deps = [
 	wlroots,
@@ -122,6 +123,28 @@ scenefx_deps = [
 	math,
 	rt,
 ]
+
+# Tracy
+if get_option('tracy_enable')
+	if get_option('buildtype') != 'debugoptimized'
+		warning('Profiling builds should set --buildtype=debugoptimized')
+	endif
+
+	scenefx_override_options += [
+		'c_std=' + (meson.version().version_compare('>=1.4.0') ? 'c23,c11' : 'c11'),
+		'warning_level=2',
+		'werror=false',
+		'wrap_mode=default',
+	]
+	scenefx_deps += dependency('tracy', static: true, required: true)
+	add_project_arguments(
+		[
+			'-DTRACY_ENABLE',
+			'-DTRACY_ON_DEMAND',
+		],
+		language: ['c', 'cpp'],
+	)
+endif
 
 subdir('protocol')
 subdir('render')
@@ -138,6 +161,7 @@ lib_scenefx = library(
 	dependencies: scenefx_deps,
 	include_directories:  [ scenefx_inc ],
 	install: true,
+	override_options: scenefx_override_options,
 )
 
 
@@ -162,3 +186,7 @@ pkgconfig.generate(
 	description: 'Wlroots effects library',
 	subdirs: versioned_name,
 )
+
+summary({
+	'tracy': get_option('tracy_enable'),
+}, bool_yn: true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option('examples', type: 'boolean', value: true, description: 'Build example applications')
 option('renderers', type: 'array', choices: ['auto', 'gles2'], value: ['auto'], description: 'Select built-in renderers')
+option('tracy_enable', type: 'boolean', value: false, description: 'Enable profiling')

--- a/render/fx_renderer/meson.build
+++ b/render/fx_renderer/meson.build
@@ -7,6 +7,7 @@ endif
 
 scenefx_files += files(
 	'util.c',
+	'tracy.c',
 	'shaders.c',
 	'pixel_format.c',
 	'fx_pass.c',

--- a/render/fx_renderer/tracy.c
+++ b/render/fx_renderer/tracy.c
@@ -1,0 +1,202 @@
+#ifdef TRACY_ENABLE
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+#include <assert.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <tracy/TracyC.h>
+#include <wlr/util/log.h>
+
+#include "render/tracy.h"
+
+// Docs:
+// - https://registry.khronos.org/OpenGL/extensions/EXT/EXT_disjoint_timer_query.txt
+// - https://github.com/wolfpld/tracy/blob/7388a476587c93f4e8e3e50d64c1400fc8c5e47e/public/tracy/TracyOpenGL.hpp
+
+#define QUERY_COUNT (64 * 1024)
+
+// Colors:
+//	From https://github.com/wolfpld/tracy/blob/7388a476587c93f4e8e3e50d64c1400fc8c5e47e/public/common/TracyColor.hpp
+#define RED4 0x8b0000
+
+static atomic_int id_counter = 0;
+
+// TODO:
+struct tracy_data {
+	struct fx_renderer *renderer;
+
+	uint8_t context_id;
+
+	uint32_t queries[QUERY_COUNT];
+	uint32_t q_head;
+	uint32_t q_tail;
+};
+
+static unsigned int get_next_query_index(struct tracy_data *tracy_data) {
+	const unsigned int id = tracy_data->q_head;
+	tracy_data->q_head = (tracy_data->q_head + 1) % QUERY_COUNT;
+	assert(tracy_data->q_head != tracy_data->q_tail);
+	return id;
+}
+
+void tracy_gpu_zone_begin(struct tracy_data *tracy_data, struct tracy_gpu_ctx *out_ctx,
+		const int line, const char *source, const char *func, const char *name) {
+	if (out_ctx == NULL || tracy_data == NULL) {
+		return;
+	}
+
+	out_ctx->tracy_data = tracy_data;
+#ifdef TRACY_ON_DEMAND
+	out_ctx->is_active = TracyCIsConnected;
+#else
+	out_ctx->is_active = true;
+#endif
+
+	if (!out_ctx->is_active) {
+		return;
+	}
+
+	// Create the query object
+	unsigned int query = get_next_query_index(tracy_data);
+	tracy_data->renderer->procs.glQueryCounterEXT(tracy_data->queries[query], GL_TIMESTAMP_EXT);
+
+	// Label the zone
+	uint64_t srcloc = ___tracy_alloc_srcloc_name(line,
+			source, strlen(source),
+			func, strlen(func),
+			name, strlen(name),
+			0);
+
+	// Begin the Tracy GPU zone
+	const struct ___tracy_gpu_zone_begin_data data = {
+		.context = tracy_data->context_id,
+		.queryId = (uint16_t) tracy_data->queries[query],
+		.srcloc = srcloc,
+	};
+	___tracy_emit_gpu_zone_begin_alloc(data);
+}
+
+void tracy_gpu_zone_end(struct tracy_gpu_ctx *ctx) {
+	if (ctx == NULL || ctx->tracy_data == NULL || !ctx->is_active) {
+		return;
+	}
+
+	// Create the query object
+	unsigned int query = get_next_query_index(ctx->tracy_data);
+	ctx->tracy_data->renderer->procs.glQueryCounterEXT(
+			ctx->tracy_data->queries[query], GL_TIMESTAMP_EXT);
+
+	// End the Tracy GPU zone
+	const struct ___tracy_gpu_zone_end_data data = {
+		.context = ctx->tracy_data->context_id,
+		.queryId = (uint16_t) ctx->tracy_data->queries[query],
+	};
+	___tracy_emit_gpu_zone_end(data);
+}
+
+void tracy_gpu_context_collect(struct tracy_data *tracy_data) {
+	if (tracy_data == NULL) {
+		return;
+	}
+
+	TracyCZoneC(ctx, RED4, true);
+
+	if (tracy_data->q_tail == tracy_data->q_head) {
+		goto done;
+	}
+
+#ifdef TRACY_ON_DEMAND
+	if (!TracyCIsConnected) {
+		tracy_data->q_head = 0;
+		tracy_data->q_tail = 0;
+		goto done;
+	}
+#endif
+
+	while (tracy_data->q_tail != tracy_data->q_head) {
+		GLint available;
+		tracy_data->renderer->procs.glGetQueryObjectivEXT(
+				tracy_data->queries[tracy_data->q_tail],
+				GL_QUERY_RESULT_AVAILABLE_EXT, &available);
+		if (!available) {
+			goto done;
+		}
+
+		GLuint64 time;
+		tracy_data->renderer->procs.glGetQueryObjectui64vEXT(
+				tracy_data->queries[tracy_data->q_tail],
+				GL_QUERY_RESULT_EXT, &time);
+
+		const struct ___tracy_gpu_time_data data = {
+			.context = tracy_data->context_id,
+			.gpuTime = time,
+			.queryId = (uint16_t) tracy_data->queries[tracy_data->q_tail],
+		};
+		___tracy_emit_gpu_time(data);
+
+		tracy_data->q_tail = (tracy_data->q_tail + 1) % QUERY_COUNT;
+	}
+
+done:
+	TracyCZoneEnd(ctx);
+}
+
+void tracy_gpu_context_destroy(struct tracy_data *tracy_data) {
+	id_counter--;
+	if (tracy_data == NULL) {
+		return;
+	}
+
+	// TODO: Anything else?
+	tracy_data->renderer->procs.glDeleteQueriesEXT(QUERY_COUNT, tracy_data->queries);
+	free(tracy_data);
+}
+
+struct tracy_data *tracy_gpu_context_new(struct fx_renderer *renderer) {
+	assert(renderer);
+
+	struct tracy_data *tracy_data = calloc(1, sizeof(*tracy_data));
+	if (tracy_data == NULL) {
+		wlr_log_errno(WLR_ERROR, "Allocation failed");
+		return NULL;
+	}
+
+	tracy_data->renderer = renderer;
+	tracy_data->context_id = ++id_counter;
+	tracy_data->q_head = 0;
+	tracy_data->q_tail = 0;
+
+	// clear disjoint flag
+	GLint64 disjoint;
+	renderer->procs.glGetInteger64vEXT(GL_GPU_DISJOINT_EXT, &disjoint);
+
+	// Create the query objects
+	renderer->procs.glGenQueriesEXT(QUERY_COUNT, tracy_data->queries);
+
+	// Get the current GL time
+	GLint64 gl_gpu_time;
+	renderer->procs.glGetInteger64vEXT(GL_TIMESTAMP_EXT, &gl_gpu_time);
+
+	const struct ___tracy_gpu_new_context_data data = {
+		.context = tracy_data->context_id,
+		.gpuTime = gl_gpu_time,
+		.period = 1.0f,
+		.flags = 0,
+		.type = 1, // `enum class GpuContextType` in TracyQueue.hpp
+	};
+	___tracy_emit_gpu_new_context(data);
+
+	// Set the custom name
+	char ctx_name[128];
+	snprintf(ctx_name, sizeof(ctx_name), "FX Renderer (GLESV%i): %s", renderer->client_version, glGetString(GL_RENDERER));
+	const struct ___tracy_gpu_context_name_data name_data = {
+		.context = tracy_data->context_id,
+		.name = ctx_name,
+		.len = strlen(ctx_name),
+	};
+	___tracy_emit_gpu_context_name(name_data);
+	return tracy_data;
+}
+#endif /* ifdef TRACY_ENABLE */

--- a/subprojects/tracy.wrap
+++ b/subprojects/tracy.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url=https://github.com/wolfpld/tracy.git
+revision=head
+depth=1


### PR DESCRIPTION
Adds support for [tracy](https://github.com/wolfpld/tracy) which is used for advanced profiling! :D

Obligatory screenshot:
![image](https://github.com/user-attachments/assets/a2cc3815-9290-4725-a76c-e6b449da091f)

How to test it with tinywl, just add the `-Dtracy_enable=true` build option:
```sh
# scenefx/
meson setup build --buildtype=debugoptimized -Dtracy_enable=true --wipe
meson compile -C build
./build/tinywl/tinywl -s foot
```

And launch the separate tracy executable, which needs to be installed/compiled separately. The latest Wayland build is pretty broken on my system (crashes a lot...), so I compiled it with LEGACY=1, and run it through a separate terminal:

```sh
# tracy/
cmake -B profiler/build -S profiler -DCMAKE_BUILD_TYPE=Release -DLEGACY=1
cmake --build profiler/build --config Release --parallel
./profiler/build/tracy-profiler
```

Without the `tracy_enable` build option enabled (the default state), tracy support is completely disabled, so no overhead.

To test it with SwayFX, apply this [patch](https://gist.github.com/ErikReider/7a507d489974a83417a8d3984cb52248) and use the same build option to meson when setting up the project.

TODO:
- [ ] Test fewer/more functions?
- [ ] Add more CPU profiling to the wlr_scene functions
- [ ] Use custom names instead of function names?
- [ ] Optional that can be added here/at a later date:
	- [ ] Add `TracyCAppInfo`?
	- [ ] Add messages?
	- [ ] Add Graphs?

Note: There's a `tracy.wrap` file in the subprojects directory which only gets automatically cloned when tracy is enabled through Meson.