### PR TITLE
docs: add troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ sudo ninja -C build/ install
 
 ## Troubleshooting
 
-## Using scenefx features breaks the compositor
+### Using scenefx features breaks the compositor
 
 This issue might be caused by compiling scenefx and wlroots with
 Clang compiler and thin LTO(`-flto=thin`) option enabled. Try to

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Install like so:
 sudo ninja -C build/ install
 ```
 
+## Troubleshooting
+
+## Using scenefx features breaks the compositor
+
+This issue might be caused by compiling scenefx and wlroots with
+Clang compiler and thin LTO(`-flto=thin`) option enabled. Try to
+compile the libraries without LTO optimizations or with GCC compiler instead.
 
 ---
 [Join our Discord](https://discord.gg/qsSx397rkh)


### PR DESCRIPTION
This `README` update is about a bug that was discovered some time ago in #130, regarding compilation with Clang and `-flto=thin`. Should be helpful if someone else will make the same mistake as I did :)