### PR TITLE
Fix #139 regressions

### DIFF
--- a/include/render/fx_renderer/fx_renderer.h
+++ b/include/render/fx_renderer/fx_renderer.h
@@ -190,6 +190,7 @@ struct fx_renderer {
 
 	struct wl_list buffers; // fx_framebuffer.link
 	struct wl_list textures; // fx_texture.link
+	struct wl_list effect_fbos; // fx_effect_framebuffers.link
 
 	// Set to true when 'wlr_renderer_begin_buffer_pass' is called instead of
 	// our custom 'fx_renderer_begin_buffer_pass' function

--- a/include/scenefx/render/fx_renderer/fx_effect_framebuffers.h
+++ b/include/scenefx/render/fx_renderer/fx_effect_framebuffers.h
@@ -9,6 +9,7 @@
  * them.
  */
 struct fx_effect_framebuffers {
+	struct wl_list link; // fx_renderer.effect_buffers
 	struct wlr_addon addon;
 
 	// Contains the blurred background for tiled windows
@@ -25,6 +26,7 @@ struct fx_effect_framebuffers {
 	pixman_region32_t blur_padding_region;
 };
 
+void fx_effect_framebuffers_destroy(struct fx_effect_framebuffers *fbos);
 struct fx_effect_framebuffers *fx_effect_framebuffers_try_get(struct wlr_output *output);
 
 #endif

--- a/render/fx_renderer/fx_effect_framebuffers.c
+++ b/render/fx_renderer/fx_effect_framebuffers.c
@@ -4,28 +4,13 @@
 #include <wlr/util/log.h>
 
 #include "render/fx_renderer/fx_renderer.h"
+#include "scenefx/render/fx_renderer/fx_renderer.h"
 #include "scenefx/render/fx_renderer/fx_effect_framebuffers.h"
-
-static inline void destroy_fx_framebuffer(struct fx_framebuffer **fx_buffer) {
-	if (!(*fx_buffer)) {
-		return;
-	}
-
-	if ((*fx_buffer)->buffer) {
-		fx_framebuffer_destroy(*fx_buffer);
-	}
-	(*fx_buffer) = NULL;
-}
 
 static void addon_handle_destroy(struct wlr_addon *addon) {
 	struct fx_effect_framebuffers *fbos = wl_container_of(addon, fbos, addon);
+	wl_list_remove(&fbos->link);
 	wlr_addon_finish(&fbos->addon);
-
-	destroy_fx_framebuffer(&fbos->optimized_blur_buffer);
-	destroy_fx_framebuffer(&fbos->blur_saved_pixels_buffer);
-	destroy_fx_framebuffer(&fbos->effects_buffer);
-	destroy_fx_framebuffer(&fbos->effects_buffer_swapped);
-
 	free(fbos);
 }
 
@@ -38,6 +23,10 @@ static bool fx_effect_framebuffers_assign(struct wlr_output *output,
 		struct fx_effect_framebuffers *fbos) {
 	wlr_addon_init(&fbos->addon, &output->addons, output, &fbos_addon_impl);
 	return true;
+}
+
+void fx_effect_framebuffers_destroy(struct fx_effect_framebuffers *fbos) {
+	addon_handle_destroy(&fbos->addon);
 }
 
 struct fx_effect_framebuffers *fx_effect_framebuffers_try_get(struct wlr_output *output) {
@@ -58,6 +47,11 @@ struct fx_effect_framebuffers *fx_effect_framebuffers_try_get(struct wlr_output 
 	return fbos;
 
 create_new:;
+	struct fx_renderer *renderer = fx_get_renderer(output->renderer);
+	if (!renderer) {
+		return NULL;
+	}
+
 	fbos = calloc(1, sizeof(*fbos));
 	if (!fbos) {
 		wlr_log(WLR_ERROR, "Could not allocate a fx_effect_framebuffers");
@@ -70,5 +64,6 @@ create_new:;
 		free(fbos);
 		return NULL;
 	}
+	wl_list_insert(&renderer->effect_fbos, &fbos->link);
 	return fbos;
 }

--- a/render/fx_renderer/fx_framebuffer.c
+++ b/render/fx_renderer/fx_framebuffer.c
@@ -162,11 +162,10 @@ void fx_framebuffer_bind(struct fx_framebuffer *fx_buffer) {
 }
 
 void fx_framebuffer_destroy(struct fx_framebuffer *fx_buffer) {
-	if (!fx_buffer || !fx_buffer->buffer) {
+	if (!fx_buffer) {
 		wlr_log(WLR_ERROR, "Trying to destroy an already destroyed fx_framebuffer");
 		return;
 	}
-	fx_buffer->buffer = NULL;
 
 	// Release the framebuffer
 	wl_list_remove(&fx_buffer->link);

--- a/render/fx_renderer/fx_renderer.c
+++ b/render/fx_renderer/fx_renderer.c
@@ -21,6 +21,7 @@
 #include "render/fx_renderer/shaders.h"
 #include "render/fx_renderer/fx_renderer.h"
 #include "render/fx_renderer/util.h"
+#include "scenefx/render/fx_renderer/fx_effect_framebuffers.h"
 #include "scenefx/render/fx_renderer/fx_renderer.h"
 #include "scenefx/render/pass.h"
 #include "util/time.h"
@@ -91,6 +92,11 @@ static void fx_renderer_destroy(struct wlr_renderer *wlr_renderer) {
 	struct fx_framebuffer *buffer, *buffer_tmp;
 	wl_list_for_each_safe(buffer, buffer_tmp, &renderer->buffers, link) {
 		fx_framebuffer_destroy(buffer);
+	}
+
+	struct fx_effect_framebuffers *fbos, *fbos_tmp;
+	wl_list_for_each_safe(fbos, fbos_tmp, &renderer->effect_fbos, link) {
+		fx_effect_framebuffers_destroy(fbos);
 	}
 
 	push_fx_debug(renderer);
@@ -406,6 +412,7 @@ struct wlr_renderer *fx_renderer_create_egl(struct wlr_egl *egl) {
 
 	wl_list_init(&renderer->buffers);
 	wl_list_init(&renderer->textures);
+	wl_list_init(&renderer->effect_fbos);
 
 	renderer->egl = egl;
 	renderer->exts_str = exts_str;


### PR DESCRIPTION
Tested by manually forcing a renderer reset by emitting `wlr_renderer.events.lost` every second.