### PR TITLE
blur: rendering time improvements

### DIFF
--- a/include/render/fx_renderer/fx_renderer.h
+++ b/include/render/fx_renderer/fx_renderer.h
@@ -182,6 +182,9 @@ struct fx_renderer {
 		struct tex_shader tex_rgba;
 		struct tex_shader tex_rgbx;
 		struct tex_shader tex_ext;
+		struct tex_shader tex_clip_rgba;
+		struct tex_shader tex_clip_rgbx;
+		struct tex_shader tex_clip_ext;
 		struct box_shadow_shader box_shadow;
 		struct blur_shader blur1;
 		struct blur_shader blur2;

--- a/include/render/fx_renderer/shaders.h
+++ b/include/render/fx_renderer/shaders.h
@@ -128,7 +128,7 @@ struct tex_shader {
 	GLint clip_radius_bottom_right;
 };
 
-bool link_tex_program(struct tex_shader *shader, GLint client_version, enum fx_tex_shader_source source);
+bool link_tex_program(struct tex_shader *shader, GLint client_version, enum fx_tex_shader_source source, bool has_clip);
 
 struct box_shadow_shader {
 	GLuint program;

--- a/render/fx_renderer/fx_renderer.c
+++ b/render/fx_renderer/fx_renderer.c
@@ -341,16 +341,29 @@ static bool link_shaders(struct fx_renderer *renderer) {
 	}
 
 	// fragment shaders
-	if (!link_tex_program(&renderer->shaders.tex_rgba, (GLint) client_version, SHADER_SOURCE_TEXTURE_RGBA)) {
+	if (!link_tex_program(&renderer->shaders.tex_rgba, (GLint) client_version, SHADER_SOURCE_TEXTURE_RGBA, false)) {
 		wlr_log(WLR_ERROR, "Could not link tex_RGBA shader");
 		goto error;
 	}
-	if (!link_tex_program(&renderer->shaders.tex_rgbx, (GLint) client_version, SHADER_SOURCE_TEXTURE_RGBX)) {
+	if (!link_tex_program(&renderer->shaders.tex_rgbx, (GLint) client_version, SHADER_SOURCE_TEXTURE_RGBX, false)) {
 		wlr_log(WLR_ERROR, "Could not link tex_RGBX shader");
 		goto error;
 	}
-	if (!link_tex_program(&renderer->shaders.tex_ext, (GLint) client_version, SHADER_SOURCE_TEXTURE_EXTERNAL)) {
+	if (!link_tex_program(&renderer->shaders.tex_ext, (GLint) client_version, SHADER_SOURCE_TEXTURE_EXTERNAL, false)) {
 		wlr_log(WLR_ERROR, "Could not link tex_EXTERNAL shader");
+		goto error;
+	}
+
+	if (!link_tex_program(&renderer->shaders.tex_clip_rgba, (GLint) client_version, SHADER_SOURCE_TEXTURE_RGBA, true)) {
+		wlr_log(WLR_ERROR, "Could not link tex_clip_RGBA shader");
+		goto error;
+	}
+	if (!link_tex_program(&renderer->shaders.tex_clip_rgbx, (GLint) client_version, SHADER_SOURCE_TEXTURE_RGBX, true)) {
+		wlr_log(WLR_ERROR, "Could not link tex_clip_RGBX shader");
+		goto error;
+	}
+	if (!link_tex_program(&renderer->shaders.tex_clip_ext, (GLint) client_version, SHADER_SOURCE_TEXTURE_EXTERNAL, true)) {
+		wlr_log(WLR_ERROR, "Could not link tex_clip_EXTERNAL shader");
 		goto error;
 	}
 

--- a/render/fx_renderer/gles2/shaders/tex.frag
+++ b/render/fx_renderer/gles2/shaders/tex.frag
@@ -1,4 +1,5 @@
 #define SOURCE %d
+#define HAS_CLIP %d
 
 #define SOURCE_TEXTURE_RGBA 1
 #define SOURCE_TEXTURE_RGBX 2
@@ -35,12 +36,14 @@ uniform float radius_top_right;
 uniform float radius_bottom_left;
 uniform float radius_bottom_right;
 
+#if HAS_CLIP
 uniform vec2 clip_size;
 uniform vec2 clip_position;
 uniform float clip_radius_top_left;
 uniform float clip_radius_top_right;
 uniform float clip_radius_bottom_left;
 uniform float clip_radius_bottom_right;
+#endif
 
 uniform bool discard_transparent;
 
@@ -64,6 +67,7 @@ void main() {
         radius_bottom_right
     );
 
+#if HAS_CLIP
     // Clipping
     float clip_corner_alpha = corner_alpha(
         clip_size - 1.0,
@@ -75,6 +79,9 @@ void main() {
     );
 
 	gl_FragColor = mix(sample_texture() * alpha, vec4(0.0), quad_corner_alpha) * clip_corner_alpha;
+#else
+    gl_FragColor = mix(sample_texture() * alpha, vec4(0.0), quad_corner_alpha);
+#endif
 
 	if (discard_transparent && gl_FragColor.a == 0.0) {
 		discard;

--- a/render/fx_renderer/gles3/shaders/tex.frag
+++ b/render/fx_renderer/gles3/shaders/tex.frag
@@ -1,6 +1,7 @@
 #version 300 es
 
 #define SOURCE %d
+#define HAS_CLIP %d
 
 #define SOURCE_TEXTURE_RGBA 1
 #define SOURCE_TEXTURE_RGBX 2
@@ -33,12 +34,14 @@ uniform float radius_top_right;
 uniform float radius_bottom_left;
 uniform float radius_bottom_right;
 
+#if HAS_CLIP
 uniform vec2 clip_size;
 uniform vec2 clip_position;
 uniform float clip_radius_top_left;
 uniform float clip_radius_top_right;
 uniform float clip_radius_bottom_left;
 uniform float clip_radius_bottom_right;
+#endif
 
 uniform bool discard_transparent;
 
@@ -64,6 +67,7 @@ void main() {
         radius_bottom_right
     );
 
+#if HAS_CLIP
     // Clipping
     float clip_corner_alpha = corner_alpha(
         clip_size - 1.0,
@@ -75,6 +79,9 @@ void main() {
     );
 
 	fragColor = mix(sample_texture() * alpha, vec4(0.0), quad_corner_alpha) * clip_corner_alpha;
+#else
+    fragColor = mix(sample_texture() * alpha, vec4(0.0), quad_corner_alpha);
+#endif
 
 	if (discard_transparent && fragColor.a == 0.0) {
 		discard;

--- a/render/fx_renderer/shaders.c
+++ b/render/fx_renderer/shaders.c
@@ -264,17 +264,17 @@ bool link_quad_grad_round_program(struct quad_grad_round_shader *shader, GLint c
 	return true;
 }
 
-bool link_tex_program(struct tex_shader *shader, GLint client_version, enum fx_tex_shader_source source) {
-	GLchar frag_src_part[2048];
-	GLchar frag_src[4096];
+bool link_tex_program(struct tex_shader *shader, GLint client_version, enum fx_tex_shader_source source, bool has_clip) {
+	GLchar frag_src_part[4096];
+	GLchar frag_src[4096 + 2048];
 	if (client_version > 2) {
 		snprintf(frag_src_part, sizeof(frag_src_part),
-			tex_frag_gles3_src, source);
+			tex_frag_gles3_src, source, has_clip);
 		snprintf(frag_src, sizeof(frag_src),
 			"%s\n%s\n", frag_src_part, corner_alpha_frag_gles3_src);
 	} else {
 		snprintf(frag_src_part, sizeof(frag_src_part),
-			tex_frag_gles2_src, source);
+			tex_frag_gles2_src, source, has_clip);
 		snprintf(frag_src, sizeof(frag_src),
 			"%s\n%s\n", frag_src_part, corner_alpha_frag_gles2_src);
 	}
@@ -298,12 +298,14 @@ bool link_tex_program(struct tex_shader *shader, GLint client_version, enum fx_t
 	shader->radius_bottom_right = glGetUniformLocation(prog, "radius_bottom_right");
 	shader->discard_transparent = glGetUniformLocation(prog, "discard_transparent");
 
-	shader->clip_size = glGetUniformLocation(prog, "clip_size");
-	shader->clip_position = glGetUniformLocation(prog, "clip_position");
-	shader->clip_radius_top_left = glGetUniformLocation(prog, "clip_radius_top_left");
-	shader->clip_radius_top_right = glGetUniformLocation(prog, "clip_radius_top_right");
-	shader->clip_radius_bottom_left = glGetUniformLocation(prog, "clip_radius_bottom_left");
-	shader->clip_radius_bottom_right = glGetUniformLocation(prog, "clip_radius_bottom_right");
+	if (has_clip) {
+		shader->clip_size = glGetUniformLocation(prog, "clip_size");
+		shader->clip_position = glGetUniformLocation(prog, "clip_position");
+		shader->clip_radius_top_left = glGetUniformLocation(prog, "clip_radius_top_left");
+		shader->clip_radius_top_right = glGetUniformLocation(prog, "clip_radius_top_right");
+		shader->clip_radius_bottom_left = glGetUniformLocation(prog, "clip_radius_bottom_left");
+		shader->clip_radius_bottom_right = glGetUniformLocation(prog, "clip_radius_bottom_right");
+	}
 
 	return true;
 }

--- a/tinywl/tinywl.c
+++ b/tinywl/tinywl.c
@@ -808,7 +808,7 @@ static void iter_xdg_scene_buffers(struct wlr_scene_buffer *buffer, int sx,
 			wlr_scene_buffer_set_corner_radius(buffer, toplevel->corner_radius,
 					CORNER_LOCATION_BOTTOM);
 
-			wlr_scene_blur_set_mask_source(toplevel->blur, &buffer->node, BLUR_MASK_IGNORE_TRANSPARENCY);
+			wlr_scene_blur_set_mask_source(toplevel->blur, &buffer->node, BLUR_MASK_IGNORE_TRANSPARENCY | BLUR_MASK_OPAQUE_REGION);
 		}
 	}
 }

--- a/tinywl/tinywl.c
+++ b/tinywl/tinywl.c
@@ -808,7 +808,7 @@ static void iter_xdg_scene_buffers(struct wlr_scene_buffer *buffer, int sx,
 			wlr_scene_buffer_set_corner_radius(buffer, toplevel->corner_radius,
 					CORNER_LOCATION_BOTTOM);
 
-			wlr_scene_blur_set_transparency_mask_source(toplevel->blur, buffer);
+			wlr_scene_blur_set_mask_source(toplevel->blur, &buffer->node, BLUR_MASK_IGNORE_TRANSPARENCY);
 		}
 	}
 }

--- a/types/scene/wlr_scene.c
+++ b/types/scene/wlr_scene.c
@@ -2184,12 +2184,16 @@ static void scene_entry_render(struct render_list_entry *entry, const struct ren
 
 		logical_to_buffer_coords(&opaque_region, data, false);
 
-		pixman_region32_t blur_render_area;
+		pixman_region32_t blur_render_area, blur_node;
 		pixman_region32_init(&blur_render_area);
 		pixman_region32_subtract(&blur_render_area, &render_region, &opaque_region);
+
 		// the render region has been expanded since it samples from the expanded area
 		// but the region being actually rendered is different, so restrict it to that
-		pixman_region32_intersect_rect(&blur_render_area, &blur_render_area, x, y, dst_box.width, dst_box.height);
+		pixman_region32_init_rect(&blur_node, x, y, dst_box.width, dst_box.height);
+		logical_to_buffer_coords(&blur_node, data, false);
+		pixman_region32_intersect(&blur_render_area, &blur_render_area, &blur_node);
+		pixman_region32_fini(&blur_node);
 
 		if (pixman_region32_empty(&blur_render_area)) {
 			pixman_region32_fini(&opaque_region);

--- a/types/scene/wlr_scene.c
+++ b/types/scene/wlr_scene.c
@@ -2226,9 +2226,6 @@ static void scene_entry_render(struct render_list_entry *entry, const struct ren
 			.ignore_transparent = tex != NULL,
 			.blur_strength = blur->strength,
 		};
-
-		// add blur will fast return if opaque region == render region
-		// so dont overdo the check here
 		fx_render_pass_add_blur(data->render_pass, &blur_options);
 		pixman_region32_fini(&opaque_region);
 	}


### PR DESCRIPTION
Adds a few more API breaks but also should allow to get some performance time back by allowing sources to define the opaque region, allowing us to render, Less

most of it was recommended by @ErikReider, and it seems to work well