### PR TITLE
implement clipping holes and outer color for quad round

### DIFF
--- a/include/render/fx_renderer/fx_renderer.h
+++ b/include/render/fx_renderer/fx_renderer.h
@@ -178,6 +178,7 @@ struct fx_renderer {
 		struct quad_shader quad;
 		struct quad_grad_shader quad_grad;
 		struct quad_round_shader quad_round;
+		struct quad_round_shader quad_round_outer_color;
 		struct quad_grad_round_shader quad_grad_round;
 		struct tex_shader tex_rgba;
 		struct tex_shader tex_rgbx;

--- a/include/render/fx_renderer/shaders.h
+++ b/include/render/fx_renderer/shaders.h
@@ -58,6 +58,7 @@ struct quad_round_shader {
 	GLuint program;
 	GLint proj;
 	GLint color;
+	GLint outer_color;
 	GLint pos_attrib;
 	GLint size;
 	GLint position;
@@ -75,7 +76,7 @@ struct quad_round_shader {
 	GLint clip_radius_bottom_right;
 };
 
-bool link_quad_round_program(struct quad_round_shader *shader, GLint client_version);
+bool link_quad_round_program(struct quad_round_shader *shader, GLint client_version, bool has_outer_color);
 
 struct quad_grad_round_shader {
 	GLuint program;

--- a/include/scenefx/render/pass.h
+++ b/include/scenefx/render/pass.h
@@ -75,6 +75,7 @@ struct fx_render_rounded_rect_options {
 	struct wlr_render_rect_options base;
 	int corner_radius;
 	enum corner_location corners;
+	struct wlr_render_color outer_color;
 	struct clipped_region clipped_region;
 };
 

--- a/include/scenefx/types/wlr_scene.h
+++ b/include/scenefx/types/wlr_scene.h
@@ -154,6 +154,8 @@ struct wlr_scene_rect {
 
 	bool accepts_input;
 	struct clipped_region clipped_region;
+	pixman_region32_t clipped_holes;
+	float outer_color[4];
 };
 
 /** A scene-graph node displaying a shadow */
@@ -531,6 +533,8 @@ void wlr_scene_rect_set_corner_radius(struct wlr_scene_rect *rect, int corner_ra
  */
 void wlr_scene_rect_set_clipped_region(struct wlr_scene_rect *rect,
 		struct clipped_region clipped_region);
+
+void wlr_scene_rect_set_outer_color(struct wlr_scene_rect *rect, const float color[static 4]);
 
 /**
  * Change the color of an existing rectangle node.

--- a/render/fx_renderer/fx_pass.c
+++ b/render/fx_renderer/fx_pass.c
@@ -565,7 +565,9 @@ void fx_render_pass_add_rounded_rect(struct fx_gles_render_pass *pass,
 	push_fx_debug(renderer);
 	setup_blending(WLR_RENDER_BLEND_MODE_PREMULTIPLIED);
 
-	struct quad_round_shader shader = renderer->shaders.quad_round;
+	bool has_outer_color = fx_options->outer_color.a > 0.0;
+
+	struct quad_round_shader shader = has_outer_color ? renderer->shaders.quad_round_outer_color : renderer->shaders.quad_round;
 
 	glUseProgram(shader.program);
 
@@ -594,6 +596,10 @@ void fx_render_pass_add_rounded_rect(struct fx_gles_render_pass *pass,
 			fx_options->corner_radius : 0);
 	glUniform1f(shader.radius_bottom_right, (CORNER_LOCATION_BOTTOM_RIGHT & corners) == CORNER_LOCATION_BOTTOM_RIGHT ?
 			fx_options->corner_radius : 0);
+
+	if (has_outer_color) {
+		glUniform4f(shader.outer_color, fx_options->outer_color.r, fx_options->outer_color.g, fx_options->outer_color.b, fx_options->outer_color.a);
+	}
 
 	render(&box, &clip_region, renderer->shaders.quad_round.pos_attrib);
 	pixman_region32_fini(&clip_region);

--- a/render/fx_renderer/fx_renderer.c
+++ b/render/fx_renderer/fx_renderer.c
@@ -335,7 +335,12 @@ static bool link_shaders(struct fx_renderer *renderer) {
 		goto error;
 	}
 
-	if (!link_quad_round_program(&renderer->shaders.quad_round, (GLint) client_version)) {
+	if (!link_quad_round_program(&renderer->shaders.quad_round, (GLint) client_version, false)) {
+		wlr_log(WLR_ERROR, "Could not link quad round shader");
+		goto error;
+	}
+
+	if (!link_quad_round_program(&renderer->shaders.quad_round_outer_color, (GLint) client_version, true)) {
 		wlr_log(WLR_ERROR, "Could not link quad round shader");
 		goto error;
 	}

--- a/render/fx_renderer/gles2/shaders/quad_round.frag
+++ b/render/fx_renderer/gles2/shaders/quad_round.frag
@@ -4,8 +4,14 @@ precision highp float;
 precision mediump float;
 #endif
 
+#define HAS_OUTER_COLOR %d
+
 varying vec4 v_color;
 varying vec2 v_texcoord;
+
+#if HAS_OUTER_COLOR
+uniform vec4 outer_color;
+#endif
 
 uniform vec2 size;
 uniform vec2 position;
@@ -33,6 +39,10 @@ void main() {
         radius_bottom_right
     );
 
+    #if !HAS_OUTER_COLOR
+    vec4 outer_color = vec4(0.0);
+    #endif
+
     // Clipping
     float clip_corner_alpha = corner_alpha(
         clip_size - 1.0,
@@ -43,5 +53,5 @@ void main() {
         clip_radius_bottom_right
     );
 
-    gl_FragColor = mix(v_color, vec4(0.0), quad_corner_alpha) * clip_corner_alpha;
+    gl_FragColor = mix(v_color, outer_color, quad_corner_alpha) * clip_corner_alpha;
 }

--- a/render/fx_renderer/gles3/shaders/quad_round.frag
+++ b/render/fx_renderer/gles3/shaders/quad_round.frag
@@ -1,9 +1,17 @@
 #version 300 es
 
+#define HAS_OUTER_COLOR %d
+
+
+
 precision highp float;
 
 in vec4 v_color;
 in vec2 v_texcoord;
+
+#if HAS_OUTER_COLOR
+uniform vec4 outer_color;
+#endif
 
 uniform vec2 size;
 uniform vec2 position;
@@ -33,6 +41,10 @@ void main() {
         radius_bottom_right
     );
 
+    #if !HAS_OUTER_COLOR
+    vec4 outer_color = vec4(0.0);
+    #endif
+
     // Clipping
     float clip_corner_alpha = corner_alpha(
         clip_size - 1.0,
@@ -43,5 +55,5 @@ void main() {
         clip_radius_bottom_right
     );
 
-    fragColor = mix(v_color, vec4(0.0), quad_corner_alpha) * clip_corner_alpha;
+    fragColor = mix(v_color, outer_color, quad_corner_alpha) * clip_corner_alpha;
 }

--- a/render/fx_renderer/shaders.c
+++ b/render/fx_renderer/shaders.c
@@ -183,13 +183,18 @@ bool link_quad_grad_program(struct quad_grad_shader *shader, GLint client_versio
 	return true;
 }
 
-bool link_quad_round_program(struct quad_round_shader *shader, GLint client_version) {
-	GLchar quad_src[4096];
+bool link_quad_round_program(struct quad_round_shader *shader, GLint client_version, bool has_outer_color) {
+	GLchar quad_src_part[4096];
+	GLchar quad_src[4096 + 2048];
 	if (client_version > 2) {
-		snprintf(quad_src, sizeof(quad_src), "%s\n%s", quad_round_frag_gles3_src,
+		snprintf(quad_src_part, sizeof(quad_src_part),
+			quad_round_frag_gles3_src, has_outer_color);
+		snprintf(quad_src, sizeof(quad_src), "%s\n%s", quad_src_part,
 			corner_alpha_frag_gles3_src);
 	} else {
-		snprintf(quad_src, sizeof(quad_src), "%s\n%s", quad_round_frag_gles2_src,
+		snprintf(quad_src_part, sizeof(quad_src_part),
+			quad_round_frag_gles2_src, has_outer_color);
+		snprintf(quad_src, sizeof(quad_src), "%s\n%s", quad_src_part,
 			corner_alpha_frag_gles2_src);
 	}
 
@@ -201,6 +206,11 @@ bool link_quad_round_program(struct quad_round_shader *shader, GLint client_vers
 
 	shader->proj = glGetUniformLocation(prog, "proj");
 	shader->color = glGetUniformLocation(prog, "color");
+
+	if (has_outer_color) {
+		shader->outer_color = glGetUniformLocation(prog, "outer_color");
+	}
+
 	shader->pos_attrib = glGetAttribLocation(prog, "pos");
 	shader->size = glGetUniformLocation(prog, "size");
 	shader->position = glGetUniformLocation(prog, "position");


### PR DESCRIPTION
This PR adds 2 features:

- the option to specify the outer color if the corner radius in a rect scene
- a clipping_holes region, that allows making multiple holes through a rect without overloading the shader