### PR TITLE
feat: add color-key transparency

### DIFF
--- a/include/render/fx_renderer/shaders.h
+++ b/include/render/fx_renderer/shaders.h
@@ -120,6 +120,11 @@ struct tex_shader {
 
 	GLint discard_transparent;
 
+	// Color-key transparency
+	GLint colorkey_enabled;
+	GLint colorkey_src;
+	GLint colorkey_dst;
+
 	GLint clip_size;
 	GLint clip_position;
 	GLint clip_radius_top_left;

--- a/include/scenefx/render/pass.h
+++ b/include/scenefx/render/pass.h
@@ -59,6 +59,10 @@ struct fx_render_texture_options {
 	int corner_radius;
 	bool discard_transparent;
 	struct clipped_region clipped_region;
+	// Color-key transparency
+	bool colorkey_enabled;
+	float colorkey_src[4];  // Source RGBA to match
+	float colorkey_dst[4];  // Destination RGBA replacement
 };
 
 struct fx_render_rect_options {

--- a/include/scenefx/types/wlr_scene.h
+++ b/include/scenefx/types/wlr_scene.h
@@ -231,6 +231,12 @@ struct wlr_scene_buffer {
 	enum corner_location corners;
 
 	float opacity;
+
+	// Color-key transparency: replace colorkey_src color with colorkey_dst
+	bool colorkey_enabled;
+	float colorkey_src[4];  // Source RGBA to match (normalized 0.0-1.0)
+	float colorkey_dst[4];  // Destination RGBA replacement (normalized 0.0-1.0)
+
 	enum wlr_scale_filter_mode filter_mode;
 	struct wlr_fbox src_box;
 	int dst_width, dst_height;
@@ -760,6 +766,16 @@ void wlr_scene_buffer_set_transform(struct wlr_scene_buffer *scene_buffer,
 */
 void wlr_scene_buffer_set_opacity(struct wlr_scene_buffer *scene_buffer,
 	float opacity);
+
+/**
+ * Sets color-key transparency for this buffer.
+ * Pixels matching colorkey_src (within tolerance) are replaced with colorkey_dst.
+ * Colors are specified as normalized RGBA values (0.0-1.0).
+ * Set enabled to false to disable colorkey transparency.
+ */
+void wlr_scene_buffer_set_colorkey(struct wlr_scene_buffer *scene_buffer,
+	bool enabled, const float colorkey_src[static 4],
+	const float colorkey_dst[static 4]);
 
 /**
 * Sets the filter mode to use when scaling the buffer

--- a/render/fx_renderer/fx_pass.c
+++ b/render/fx_renderer/fx_pass.c
@@ -344,7 +344,8 @@ void fx_render_pass_add_texture(struct fx_gles_render_pass *pass,
 	bool has_alpha = texture->has_alpha
 		|| alpha < 1.0
 		|| fx_options->corner_radius > 0
-		|| fx_options->discard_transparent;
+		|| fx_options->discard_transparent
+		|| (fx_options->colorkey_enabled && fx_options->colorkey_dst[3] < 1.0);
 	setup_blending(!has_alpha ? WLR_RENDER_BLEND_MODE_NONE : options->blend_mode);
 
 	pixman_region32_t clip_region;
@@ -394,6 +395,12 @@ void fx_render_pass_add_texture(struct fx_gles_render_pass *pass,
 	glUniform2f(shader->size, clip_box->width, clip_box->height);
 	glUniform2f(shader->position, clip_box->x, clip_box->y);
 	glUniform1f(shader->discard_transparent, fx_options->discard_transparent);
+
+	// Color-key transparency
+	glUniform1i(shader->colorkey_enabled, fx_options->colorkey_enabled);
+	glUniform4fv(shader->colorkey_src, 1, fx_options->colorkey_src);
+	glUniform4fv(shader->colorkey_dst, 1, fx_options->colorkey_dst);
+
 	glUniform1f(shader->radius_top_left, (CORNER_LOCATION_TOP_LEFT & corners) == CORNER_LOCATION_TOP_LEFT ?
 			fx_options->corner_radius : 0);
 	glUniform1f(shader->radius_top_right, (CORNER_LOCATION_TOP_RIGHT & corners) == CORNER_LOCATION_TOP_RIGHT ?

--- a/render/fx_renderer/gles3/shaders/tex.frag
+++ b/render/fx_renderer/gles3/shaders/tex.frag
@@ -42,6 +42,11 @@ uniform float clip_radius_bottom_right;
 
 uniform bool discard_transparent;
 
+// Color-key transparency
+uniform bool colorkey_enabled;
+uniform vec4 colorkey_src;
+uniform vec4 colorkey_dst;
+
 out vec4 fragColor;
 
 vec4 sample_texture() {
@@ -55,6 +60,17 @@ vec4 sample_texture() {
 float corner_alpha(vec2 size, vec2 position, float round_tl, float round_tr, float round_bl, float round_br);
 
 void main() {
+    vec4 c = sample_texture();
+
+    // Color-key transparency: replace matching colors
+    if (colorkey_enabled) {
+        // Use small epsilon for float comparison (~1/255 tolerance)
+        vec4 diff = abs(c - colorkey_src);
+        if (all(lessThan(diff, vec4(0.004)))) {
+            c = colorkey_dst;
+        }
+    }
+
     float quad_corner_alpha = corner_alpha(
         size - 0.5,
         position + 0.25,
@@ -74,7 +90,7 @@ void main() {
         clip_radius_bottom_right
     );
 
-	fragColor = mix(sample_texture() * alpha, vec4(0.0), quad_corner_alpha) * clip_corner_alpha;
+	fragColor = mix(c * alpha, vec4(0.0), quad_corner_alpha) * clip_corner_alpha;
 
 	if (discard_transparent && fragColor.a == 0.0) {
 		discard;

--- a/render/fx_renderer/shaders.c
+++ b/render/fx_renderer/shaders.c
@@ -265,8 +265,8 @@ bool link_quad_grad_round_program(struct quad_grad_round_shader *shader, GLint c
 }
 
 bool link_tex_program(struct tex_shader *shader, GLint client_version, enum fx_tex_shader_source source) {
-	GLchar frag_src_part[2048];
-	GLchar frag_src[4096];
+	GLchar frag_src_part[4096];
+	GLchar frag_src[8192];
 	if (client_version > 2) {
 		snprintf(frag_src_part, sizeof(frag_src_part),
 			tex_frag_gles3_src, source);
@@ -297,6 +297,11 @@ bool link_tex_program(struct tex_shader *shader, GLint client_version, enum fx_t
 	shader->radius_bottom_left = glGetUniformLocation(prog, "radius_bottom_left");
 	shader->radius_bottom_right = glGetUniformLocation(prog, "radius_bottom_right");
 	shader->discard_transparent = glGetUniformLocation(prog, "discard_transparent");
+
+	// Color-key transparency
+	shader->colorkey_enabled = glGetUniformLocation(prog, "colorkey_enabled");
+	shader->colorkey_src = glGetUniformLocation(prog, "colorkey_src");
+	shader->colorkey_dst = glGetUniformLocation(prog, "colorkey_dst");
 
 	shader->clip_size = glGetUniformLocation(prog, "clip_size");
 	shader->clip_position = glGetUniformLocation(prog, "clip_position");


### PR DESCRIPTION
Implemented as more of a color search-and-replace feature.

This allows enabling a transparent background on apps which are not alpha-aware - pick an unlikely color to use as the background, then configure SwayFX to remap it to another color with an alpha value.
