### PR TITLE
add linux/stddef.h for musl compatibility

### DIFF
--- a/include/scenefx/types/fx/clipped_region.h
+++ b/include/scenefx/types/fx/clipped_region.h
@@ -1,6 +1,7 @@
 #ifndef SCENEFX_TYPES_FX_CLIPPED_REGION_H
 #define SCENEFX_TYPES_FX_CLIPPED_REGION_H
 
+#include <linux/stddef.h>
 #include <wlr/util/box.h>
 
 // uint16_t is a reasonable enough range for corner radius


### PR DESCRIPTION
The __always_inline macro is defined in <linux/stddef.h>. While glibc includes this by default, musl does not. This commit explicitly includes <linux/stddef.h> to ensure compatibility with musl libc platforms.

```
In file included from ../tinywl/tinywl.c:8:
../include/scenefx/types/fx/clipped_region.h:18:8: error: unknown type name '__always_inline'
   18 | static __always_inline uint16_t corner_radius_clamp(int radius) {
      |        ^~~~~~~~~~~~~~~
```