### PR TITLE
fix gles border on nvidia proprietary driver by forcing high prec

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -169,6 +169,10 @@ if get_option('tracy_enable')
 	)
 endif
 
+if get_option('force_fragment_shader_precision_high')
+  add_project_arguments('-DFORCE_GL_FRAGMENT_PRECISION_HIGH=1', language: 'c')
+endif
+
 subdir('protocol')
 subdir('render')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,3 +2,4 @@ option('examples', type: 'boolean', value: true, description: 'Build example app
 option('renderers', type: 'array', choices: ['auto', 'gles2'], value: ['auto'], description: 'Select built-in renderers')
 option('color-management', type: 'feature', value: 'auto', description: 'Enable support for color management')
 option('tracy_enable', type: 'boolean', value: false, description: 'Enable profiling')
+option( 'force_fragment_shader_precision_high', type: 'boolean', value: false)

--- a/render/egl.c
+++ b/render/egl.c
@@ -412,7 +412,11 @@ static bool egl_init(struct wlr_egl *egl, EGLenum platform,
 	EGLint attribs[7];
 
 	attribs[atti++] = EGL_CONTEXT_CLIENT_VERSION;
+#ifdef FORCE_GL_FRAGMENT_PRECISION_HIGH
+	attribs[atti++] = 3;
+#else
 	attribs[atti++] = 2;
+#endif
 
 	// Request a high priority context if possible
 	// TODO: only do this if we're running as the DRM master

--- a/render/fx_renderer/shaders.c
+++ b/render/fx_renderer/shaders.c
@@ -23,7 +23,20 @@
 
 GLuint compile_shader(GLuint type, const GLchar *src) {
 	GLuint shader = glCreateShader(type);
-	glShaderSource(shader, 1, &src, NULL);
+
+	const char *prefix = "";
+#ifdef FORCE_GL_FRAGMENT_PRECISION_HIGH
+	if (type == GL_FRAGMENT_SHADER) {
+		prefix =
+			"#ifndef GL_FRAGMENT_PRECISION_HIGH\n"
+			"#define GL_FRAGMENT_PRECISION_HIGH 1\n"
+			"#endif\n";
+	}
+#endif
+
+	const GLchar *sources[] = { prefix, src };
+
+	glShaderSource(shader, 2, sources, NULL);
 	glCompileShader(shader);
 
 	GLint ok;


### PR DESCRIPTION
On nvidia proprietary driver, the border are badly rendered due to medium precision float,

however, forcing high precision float in the fragment shaders and setting the EGL_CONTEXT_CLIENT_VERSION to 3 seems to render the border normally (  tested on : NVIDIA GeForce RTX 2080  /  Driver Version: 590.48.01).

To not  break compatibility with other gpu, this commit add an option : force_fragment_shader_precision_high , so the default build remain unchanged.

to test :  ```meson setup -Dscenefx:force_fragment_shader_precision_high=true ...``` 