### PR TITLE
Fixed offscreen_buffers not dropping wlr_buffers

### DIFF
--- a/include/render/fx_renderer/fx_renderer.h
+++ b/include/render/fx_renderer/fx_renderer.h
@@ -63,6 +63,10 @@ struct fx_framebuffer *fx_framebuffer_get_or_create(struct fx_renderer *renderer
 
 void fx_framebuffer_bind(struct fx_framebuffer *buffer);
 
+/**
+ * Destroy the fx_framebuffer.
+ * Note: Doesn't drop the wlr_buffer, so should only be used internally.
+ */
 void fx_framebuffer_destroy(struct fx_framebuffer *buffer);
 
 ///

--- a/render/fx_renderer/fx_offscreen_buffers.c
+++ b/render/fx_renderer/fx_offscreen_buffers.c
@@ -12,23 +12,23 @@ static void addon_handle_destroy(struct wlr_addon *addon) {
 
 	// Make sure to free the buffers
 	if (fbos->optimized_blur_buffer != NULL) {
-		fx_framebuffer_destroy(fbos->optimized_blur_buffer);
+		wlr_buffer_drop(fbos->optimized_blur_buffer->buffer);
 		fbos->optimized_blur_buffer = NULL;
 	}
 	if (fbos->optimized_no_blur_buffer != NULL) {
-		fx_framebuffer_destroy(fbos->optimized_no_blur_buffer);
+		wlr_buffer_drop(fbos->optimized_no_blur_buffer->buffer);
 		fbos->optimized_no_blur_buffer = NULL;
 	}
 	if (fbos->blur_saved_pixels_buffer != NULL) {
-		fx_framebuffer_destroy(fbos->blur_saved_pixels_buffer);
+		wlr_buffer_drop(fbos->blur_saved_pixels_buffer->buffer);
 		fbos->blur_saved_pixels_buffer = NULL;
 	}
 	if (fbos->effects_buffer != NULL) {
-		fx_framebuffer_destroy(fbos->effects_buffer);
+		wlr_buffer_drop(fbos->effects_buffer->buffer);
 		fbos->effects_buffer = NULL;
 	}
 	if (fbos->effects_buffer_swapped != NULL) {
-		fx_framebuffer_destroy(fbos->effects_buffer_swapped);
+		wlr_buffer_drop(fbos->effects_buffer_swapped->buffer);
 		fbos->effects_buffer_swapped = NULL;
 	}
 


### PR DESCRIPTION
Should fix the issue that @DreamMaoMao experienced where we were freeing our offscreen GLES2 buffers without dropping the underlying wlr_buffers, leading to a nasty VRAM memory leak when hot-plugging outputs or switching TTYs.