### PR TITLE
tinywl: Add xdg-shell server as a dependency.

### DIFF
--- a/tinywl/meson.build
+++ b/tinywl/meson.build
@@ -1,7 +1,5 @@
 executable(
 	'tinywl',
-	['tinywl.c',
-        protocols_client_header['xdg-shell'],
-        protocols_server_header['xdg-shell']],
+	['tinywl.c', protocols_server_header['xdg-shell']],
 	dependencies: scenefx,
 )

--- a/tinywl/meson.build
+++ b/tinywl/meson.build
@@ -1,5 +1,7 @@
 executable(
 	'tinywl',
-	['tinywl.c', protocols_client_header['xdg-shell']],
+	['tinywl.c',
+        protocols_client_header['xdg-shell'],
+        protocols_server_header['xdg-shell']],
 	dependencies: scenefx,
 )


### PR DESCRIPTION
Under some configurations when `-D examples=true` is passed to `meson`, ninja will fail to build the `tinywl/tinywl.p/tinywl.c.o` target because `protocols_server_header['xdg-shell']` wasn't added as a source. `tinywl/tinywl.p/tinywl.c` includes `xdg-shell-protocol.h` which is generated from `protocols_server_header['xdg-shell']`, but if parallelism is too high, or when using samurai, since the dependency information is incomplete, the protocol server header won't generate before `tinywl/tinywl.p/tinywl.c.o` is attempted to be built, and will then proceed to fail.

This commit/PR fixes the issue for all configurations.