### PR TITLE
WIP: bump scenefx to 0.5, switch to wlroots 0.20

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772173633,
-        "narHash": "sha256-MOH58F4AIbCkh6qlQcwMycyk5SWvsqnS/TCfnqDlpj4=",
+        "lastModified": 1775403759,
+        "narHash": "sha256-cGyKiTspHEUx3QwAnV3RfyT+VOXhHLs+NEr17HU34Wo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c0f3d81a7ddbc2b1332be0d8481a672b4f6004d6",
+        "rev": "5e11f7acce6c3469bef9df154d78534fa7ae8b6c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
               mesa # gbm
               wayland # wayland-server
               wayland-protocols
-              wlroots_0_19
+              wlroots
               libgbm
               libxcb
               libxcb-wm

--- a/include/scenefx/types/wlr_scene.h
+++ b/include/scenefx/types/wlr_scene.h
@@ -22,6 +22,7 @@
 #include <pixman.h>
 #include <time.h>
 #include <wayland-server-core.h>
+#include <wlr/render/color.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_damage_ring.h>
 #include <wlr/types/wlr_linux_dmabuf_v1.h>
@@ -39,6 +40,8 @@ struct wlr_xdg_surface;
 struct wlr_layer_surface_v1;
 struct wlr_drag_icon;
 struct wlr_surface;
+struct wlr_color_manager_v1;
+struct wlr_drm_syncobj_timeline;
 
 struct wlr_scene_node;
 struct wlr_scene_buffer;
@@ -108,11 +111,15 @@ struct wlr_scene {
 	// May be NULL
 	struct wlr_linux_dmabuf_v1 *linux_dmabuf_v1;
 	struct wlr_gamma_control_manager_v1 *gamma_control_manager_v1;
+	struct wlr_color_manager_v1 *color_manager_v1;
+
+	bool restack_xwayland_surfaces;
 
 	struct {
 		struct wl_listener linux_dmabuf_v1_destroy;
 		struct wl_listener gamma_control_manager_v1_destroy;
 		struct wl_listener gamma_control_manager_v1_set_gamma;
+		struct wl_listener color_manager_v1_destroy;
 
 		enum wlr_scene_debug_damage_option debug_damage_option;
 		bool direct_scanout;
@@ -134,8 +141,6 @@ struct wlr_scene_surface {
 		struct wlr_addon addon;
 
 		struct wl_listener outputs_update;
-		struct wl_listener output_enter;
-		struct wl_listener output_leave;
 		struct wl_listener output_sample;
 		struct wl_listener frame_done;
 		struct wl_listener surface_destroy;
@@ -196,6 +201,13 @@ struct wlr_scene_outputs_update_event {
 struct wlr_scene_output_sample_event {
 	struct wlr_scene_output *output;
 	bool direct_scanout;
+	struct wlr_drm_syncobj_timeline *release_timeline;
+	uint64_t release_point;
+};
+
+struct wlr_scene_frame_done_event {
+	struct wlr_scene_output *output;
+	struct timespec when;
 };
 
 /** A scene-graph node displaying a buffer */
@@ -210,7 +222,7 @@ struct wlr_scene_buffer {
 		struct wl_signal output_enter; // struct wlr_scene_output
 		struct wl_signal output_leave; // struct wlr_scene_output
 		struct wl_signal output_sample; // struct wlr_scene_output_sample_event
-		struct wl_signal frame_done; // struct timespec
+		struct wl_signal frame_done; // struct wlr_scene_frame_done_event
 	} events;
 
 	// May be NULL
@@ -219,8 +231,7 @@ struct wlr_scene_buffer {
 	/**
 	 * The output that the largest area of this buffer is displayed on.
 	 * This may be NULL if the buffer is not currently displayed on any
-	 * outputs. This is the output that should be used for frame callbacks,
-	 * presentation feedback, etc.
+	 * outputs.
 	 */
 	struct wlr_scene_output *primary_output;
 
@@ -232,6 +243,10 @@ struct wlr_scene_buffer {
 	int dst_width, dst_height;
 	enum wl_output_transform transform;
 	pixman_region32_t opaque_region;
+	enum wlr_color_transfer_function transfer_function;
+	enum wlr_color_named_primaries primaries;
+	enum wlr_color_encoding color_encoding;
+	enum wlr_color_range color_range;
 
 	struct linked_node blur;
 
@@ -782,11 +797,23 @@ void wlr_scene_buffer_set_corner_radius(struct wlr_scene_buffer *scene_buffer,
 */
 void wlr_scene_buffer_set_corner_radii(struct wlr_scene_buffer *scene_buffer,
 	struct fx_corner_radii corner_radii);
+void wlr_scene_buffer_set_transfer_function(struct wlr_scene_buffer *scene_buffer,
+	enum wlr_color_transfer_function transfer_function);
+
+void wlr_scene_buffer_set_primaries(struct wlr_scene_buffer *scene_buffer,
+	enum wlr_color_named_primaries primaries);
+
+void wlr_scene_buffer_set_color_encoding(struct wlr_scene_buffer *scene_buffer,
+	enum wlr_color_encoding encoding);
+
+void wlr_scene_buffer_set_color_range(struct wlr_scene_buffer *scene_buffer,
+	enum wlr_color_range range);
+
 /**
  * Calls the buffer's frame_done signal.
  */
 void wlr_scene_buffer_send_frame_done(struct wlr_scene_buffer *scene_buffer,
-	struct timespec *now);
+	struct wlr_scene_frame_done_event *event);
 
 /**
  * Add a viewport for the specified output to the scene-graph.
@@ -851,6 +878,11 @@ void wlr_scene_timer_finish(struct wlr_scene_timer *timer);
  */
 void wlr_scene_output_send_frame_done(struct wlr_scene_output *scene_output,
 	struct timespec *now);
+
+/**
+ * Asserts that a struct wlr_color_manager_v1 hasn't already been set for the scene.
+ */
+void wlr_scene_set_color_manager_v1(struct wlr_scene *scene, struct wlr_color_manager_v1 *manager);
 /**
  * Call `iterator` on each buffer in the scene-graph visible on the output,
  * with the buffer's position in layout coordinates. The function is called

--- a/meson.build
+++ b/meson.build
@@ -79,7 +79,7 @@ wayland_server = dependency('wayland-server',
 )
 
 wlroots_options = [ 'examples=false' ]
-wlroots_version = ['>=0.20.0']
+wlroots_version = ['>=0.20.0', '<0.21.0']
 wlroots = dependency('wlroots-0.20',
 	version: wlroots_version,
 	default_options: wlroots_options,

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
 	'scenefx',
 	'c',
-	version: '0.4.1',
+	version: '0.5.0',
 	license: 'MIT',
 	meson_version: '>=1.3',
 	default_options: [
@@ -79,8 +79,8 @@ wayland_server = dependency('wayland-server',
 )
 
 wlroots_options = [ 'examples=false' ]
-wlroots_version = ['>=0.19.0', '<0.20.0']
-wlroots = dependency('wlroots-0.19',
+wlroots_version = ['>=0.20.0']
+wlroots = dependency('wlroots-0.20',
 	version: wlroots_version,
 	default_options: wlroots_options,
 	required: false,

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -1,5 +1,5 @@
 wayland_protos = dependency('wayland-protocols',
-	version: '>=1.41',
+	version: '>=1.47',
 	fallback: 'wayland-protocols',
 	default_options: ['tests=false'],
 )

--- a/types/scene/wlr_scene.c
+++ b/types/scene/wlr_scene.c
@@ -9,6 +9,7 @@
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_damage_ring.h>
+#include <wlr/types/wlr_color_management_v1.h>
 #include <wlr/types/wlr_gamma_control_v1.h>
 #include <wlr/types/wlr_linux_dmabuf_v1.h>
 #include <wlr/types/wlr_presentation_time.h>
@@ -1540,9 +1541,9 @@ void wlr_scene_buffer_set_transform(struct wlr_scene_buffer *scene_buffer,
 }
 
 void wlr_scene_buffer_send_frame_done(struct wlr_scene_buffer *scene_buffer,
-		struct timespec *now) {
+		struct wlr_scene_frame_done_event *event) {
 	if (!pixman_region32_empty(&scene_buffer->node.visible)) {
-		wl_signal_emit_mutable(&scene_buffer->events.frame_done, now);
+		wl_signal_emit_mutable(&scene_buffer->events.frame_done, event);
 	}
 }
 
@@ -1554,6 +1555,42 @@ void wlr_scene_buffer_set_opacity(struct wlr_scene_buffer *scene_buffer,
 
 	assert(opacity >= 0 && opacity <= 1);
 	scene_buffer->opacity = opacity;
+	scene_node_update(&scene_buffer->node, NULL);
+}
+
+void wlr_scene_buffer_set_transfer_function(struct wlr_scene_buffer *scene_buffer,
+		enum wlr_color_transfer_function transfer_function) {
+	if (scene_buffer->transfer_function == transfer_function) {
+		return;
+	}
+	scene_buffer->transfer_function = transfer_function;
+	scene_node_update(&scene_buffer->node, NULL);
+}
+
+void wlr_scene_buffer_set_primaries(struct wlr_scene_buffer *scene_buffer,
+		enum wlr_color_named_primaries primaries) {
+	if (scene_buffer->primaries == primaries) {
+		return;
+	}
+	scene_buffer->primaries = primaries;
+	scene_node_update(&scene_buffer->node, NULL);
+}
+
+void wlr_scene_buffer_set_color_encoding(struct wlr_scene_buffer *scene_buffer,
+		enum wlr_color_encoding encoding) {
+	if (scene_buffer->color_encoding == encoding) {
+		return;
+	}
+	scene_buffer->color_encoding = encoding;
+	scene_node_update(&scene_buffer->node, NULL);
+}
+
+void wlr_scene_buffer_set_color_range(struct wlr_scene_buffer *scene_buffer,
+		enum wlr_color_range range) {
+	if (scene_buffer->color_range == range) {
+		return;
+	}
+	scene_buffer->color_range = range;
 	scene_node_update(&scene_buffer->node, NULL);
 }
 
@@ -2195,6 +2232,22 @@ void wlr_scene_set_gamma_control_manager_v1(struct wlr_scene *scene,
 	scene->gamma_control_manager_v1_set_gamma.notify =
 		scene_handle_gamma_control_manager_v1_set_gamma;
 	wl_signal_add(&gamma_control->events.set_gamma, &scene->gamma_control_manager_v1_set_gamma);
+}
+
+static void scene_handle_color_manager_v1_destroy(struct wl_listener *listener, void *data) {
+	struct wlr_scene *scene = wl_container_of(listener, scene, color_manager_v1_destroy);
+	wl_list_remove(&scene->color_manager_v1_destroy.link);
+	scene->color_manager_v1 = NULL;
+}
+
+void wlr_scene_set_color_manager_v1(struct wlr_scene *scene,
+		struct wlr_color_manager_v1 *manager) {
+	assert(scene->color_manager_v1 == NULL);
+	scene->color_manager_v1 = manager;
+
+	scene->color_manager_v1_destroy.notify =
+		scene_handle_color_manager_v1_destroy;
+	wl_signal_add(&manager->events.destroy, &scene->color_manager_v1_destroy);
 }
 
 static void scene_output_handle_destroy(struct wlr_addon *addon) {
@@ -3230,7 +3283,11 @@ static void scene_node_send_frame_done(struct wlr_scene_node *node,
 			wlr_scene_buffer_from_node(node);
 
 		if (scene_buffer->primary_output == scene_output) {
-			wlr_scene_buffer_send_frame_done(scene_buffer, now);
+			struct wlr_scene_frame_done_event event = {
+				.output = scene_output,
+				.when = *now,
+			};
+			wlr_scene_buffer_send_frame_done(scene_buffer, &event);
 		}
 	} else if (node->type == WLR_SCENE_NODE_TREE) {
 		struct wlr_scene_tree *scene_tree = wlr_scene_tree_from_node(node);


### PR DESCRIPTION
For now wlr_scene crashes when moving to 0.20 and I'm not sure 

```gdb
00:00:00.265 [tinywl/tinywl.c:1249] Running Wayland compositor on WAYLAND_DISPLAY=wayland-1
00:00:00.266 [types/output/render.c:123] Attaching empty buffer to output for modeset
00:00:00.266 [types/output/swapchain.c:27] Choosing primary buffer format XR24 (0x34325258) for output 'WL-1'
00:00:00.266 [types/output/swapchain.c:96] Testing swapchain for output 'WL-1'
00:00:00.266 [render/swapchain.c:103] Allocating new swapchain buffer
00:00:00.267 [render/allocator/gbm.c:118] Allocated 697x746 GBM buffer with format XR24 (0x34325258), modifier GFX11,64KB_R_X,PIPE_XOR_BITS=2,PACKERS=2,DCC,DCC_MAX_COMPRESSED_BLOCK=128B,DCC_INDEPENDENT_128B,DCC_PIPE_ALIGN (0x020000001046BB04)
00:00:00.267 [render/fx_renderer/fx_framebuffer.c:153] Created GL FBO for buffer 697x746
00:00:00.270 [backend/wayland/output.c:217] DMA-BUF imported into parent Wayland compositor
00:00:00.301 [render/swapchain.c:103] Allocating new swapchain buffer
00:00:00.301 [render/allocator/gbm.c:118] Allocated 697x746 GBM buffer with format XR24 (0x34325258), modifier GFX11,64KB_R_X,PIPE_XOR_BITS=2,PACKERS=2,DCC,DCC_MAX_COMPRESSED_BLOCK=128B,DCC_INDEPENDENT_128B,DCC_PIPE_ALIGN (0x020000001046BB04)
00:00:00.302 [render/fx_renderer/fx_framebuffer.c:153] Created GL FBO for buffer 697x746
00:00:00.302 [render/allocator/gbm.c:118] Allocated 697x746 GBM buffer with format XB24 (0x34324258), modifier GFX11,64KB_R_X,PIPE_XOR_BITS=2,PACKERS=2,DCC,DCC_MAX_COMPRESSED_BLOCK=128B,DCC_INDEPENDENT_128B,DCC_PIPE_ALIGN (0x020000001046BB04)
00:00:00.302 [render/fx_renderer/fx_framebuffer.c:153] Created GL FBO for buffer 697x746
00:00:00.303 [render/allocator/gbm.c:118] Allocated 697x746 GBM buffer with format AB24 (0x34324241), modifier GFX11,64KB_R_X,PIPE_XOR_BITS=2,PACKERS=2,DCC,DCC_MAX_COMPRESSED_BLOCK=128B,DCC_INDEPENDENT_128B,DCC_PIPE_ALIGN (0x020000001046BB04)
00:00:00.303 [render/fx_renderer/fx_framebuffer.c:153] Created GL FBO for buffer 697x746
00:00:00.303 [render/allocator/gbm.c:118] Allocated 697x746 GBM buffer with format AB24 (0x34324241), modifier GFX11,64KB_R_X,PIPE_XOR_BITS=2,PACKERS=2,DCC,DCC_MAX_COMPRESSED_BLOCK=128B,DCC_INDEPENDENT_128B,DCC_PIPE_ALIGN (0x020000001046BB04)
00:00:00.303 [render/fx_renderer/fx_framebuffer.c:153] Created GL FBO for buffer 697x746
00:00:00.304 [render/allocator/gbm.c:118] Allocated 697x746 GBM buffer with format XB24 (0x34324258), modifier GFX11,64KB_R_X,PIPE_XOR_BITS=2,PACKERS=2,DCC,DCC_MAX_COMPRESSED_BLOCK=128B,DCC_INDEPENDENT_128B,DCC_PIPE_ALIGN (0x020000001046BB04)
00:00:00.304 [render/fx_renderer/fx_framebuffer.c:153] Created GL FBO for buffer 697x746
00:00:00.305 [render/allocator/gbm.c:118] Allocated 697x746 GBM buffer with format XB24 (0x34324258), modifier GFX11,64KB_R_X,PIPE_XOR_BITS=2,PACKERS=2,DCC,DCC_MAX_COMPRESSED_BLOCK=128B,DCC_INDEPENDENT_128B,DCC_PIPE_ALIGN (0x020000001046BB04)
00:00:00.305 [render/fx_renderer/fx_framebuffer.c:153] Created GL FBO for buffer 697x746
00:00:00.308 [backend/wayland/output.c:217] DMA-BUF imported into parent Wayland compositor
warn: wayland.c:1821: compositor does not implement the primary selection interface
warn: wayland.c:1824: compositor does not implement XDG activation, bell.urgent will fall back to coloring the window margins red
warn: wayland.c:1830: compositor does not implement fractional scaling
warn: wayland.c:1833: compositor does not implement server-side cursors, falling back to client-side cursors
warn: wayland.c:1838: compositor does not implement the xdg-toplevel-icon protocol
warn: wayland.c:1843: text input interface not implemented by compositor; IME will be disabled
warn: wayland.c:2137: no decoration manager available - using CSDs unconditionally
00:00:00.387 [types/wlr_compositor.c:786] New wlr_surface 0x555555e0b850 (res 0x555555f9a370)
00:00:00.387 [types/wlr_compositor.c:786] New wlr_surface 0x555555e0bc80 (res 0x555555f99ef0)
00:00:00.387 [types/xdg_shell/wlr_xdg_surface.c:441] new xdg_surface 0x5555560828a0 (res 0x555555f99cb0)
00:00:00.387 [types/wlr_compositor.c:786] New wlr_surface 0x555555e0f660 (res 0x555555f98bd0)
00:00:00.429 [types/wlr_compositor.c:786] New wlr_surface 0x555556087190 (res 0x555555f8c7f0)
00:00:00.429 [types/wlr_compositor.c:786] New wlr_surface 0x555556087560 (res 0x555555f98870)
00:00:00.429 [types/wlr_compositor.c:786] New wlr_surface 0x555556087a60 (res 0x555555f9bd50)
00:00:00.429 [types/wlr_compositor.c:786] New wlr_surface 0x555556087f10 (res 0x555555f9b9f0)
00:00:00.429 [types/wlr_compositor.c:786] New wlr_surface 0x5555560883c0 (res 0x555555f9b450)
00:00:00.429 [types/wlr_compositor.c:786] New wlr_surface 0x555556088900 (res 0x555556088cd0)
00:00:00.429 [types/wlr_compositor.c:786] New wlr_surface 0x555556088ed0 (res 0x5555560892a0)
00:00:00.429 [types/wlr_compositor.c:786] New wlr_surface 0x5555560896b0 (res 0x555556089a80)

Thread 1 "tinywl" received signal SIGSEGV, Segmentation fault.
0x00007ffff7982640 in pixman_region32_copy () from /usr/lib/libpixman-1.so.0
(gdb) bt full
#0  0x00007ffff7982640 in pixman_region32_copy () at /usr/lib/libpixman-1.so.0
#1  0x00007ffff7f9d96d in scene_node_opaque_region (node=0x5555560ceab0, x=0, y=0, opaque=0x7fffffff9c70)
    at ../types/scene/wlr_scene.c:367
        scene_buffer = 0x5555560ceab0
        width = 703
        height = 5
#2  0x00007ffff7f9ea0e in scene_node_update_iterator (node=0x5555560ceab0, lx=0, ly=0, _data=0x7fffffffa030)
    at ../types/scene/wlr_scene.c:712
        opaque = {extents = {x1 = 0, y1 = 0, x2 = 0, y2 = 0}, data = 0x7ffff79cec10}
        data = 0x7fffffffa030
        box = {x = 0, y = 0, width = 703, height = 5}
#3  0x00007ffff7f9d50f in _scene_nodes_in_box
    (node=0x5555560ceab0, box=0x7fffffffa040, iterator=0x7ffff7f9e8b3 <scene_node_update_iterator>, user_data=0x7fffffffa030, lx=0, ly=0) at ../types/scene/wlr_scene.c:278
        scene_tree = 0xd37adc27760df00
        child = 0x555555f899c0
        node_box = {x = 0, y = 0, width = 703, height = 5}
#4  0x00007ffff7f9d46c in _scene_nodes_in_box
    (node=0x5555560ca110, box=0x7fffffffa040, iterator=0x7ffff7f9e8b3 <scene_node_update_iterator>, user_data=0x7fffffffa030, lx=0, ly=0) at ../types/scene/wlr_scene.c:264
        scene_tree = 0x5555560ca110
        child = 0x5555560ceab0
        node_box = {x = -24592, y = 32767, width = 1442419344, height = 21845}
#5  0x00007ffff7f9d46c in _scene_nodes_in_box
    (node=0x555555f99290, box=0x7fffffffa040, iterator=0x7ffff7f9e8b3 <scene_node_update_iterator>, user_data=0x7fffffffa030, lx=0, ly=0) at ../types/scene/wlr_scene.c:264
        scene_tree = 0x555555f99290
        child = 0x5555560ca110
        node_box = {x = 1, y = 0, width = 1442420496, height = 21845}
--Type <RET> for more, q to quit, c to continue without paging--
#6  0x00007ffff7f9d46c in _scene_nodes_in_box
    (node=0x555555f99710, box=0x7fffffffa040, iterator=0x7ffff7f9e8b3 <scene_node_update_iterator>, user_data=0x7fffffffa030, lx=0, ly=0) at ../types/scene/wlr_scene.c:264
        scene_tree = 0x555555f99710
        child = 0x555555f99290
        node_box = {x = 5, y = 0, width = 1442420784, height = 21845}
#7  0x00007ffff7f9d46c in _scene_nodes_in_box
    (node=0x555555f99830, box=0x7fffffffa040, iterator=0x7ffff7f9e8b3 <scene_node_update_iterator>, user_data=0x7fffffffa030, lx=0, ly=0) at ../types/scene/wlr_scene.c:264
        scene_tree = 0x555555f99830
        child = 0x555555f99710
        node_box = {x = 5, y = 32767, width = 1442070432, height = 21845}
#8  0x00007ffff7f9d46c in _scene_nodes_in_box
    (node=0x555555f43fa0, box=0x7fffffffa040, iterator=0x7ffff7f9e8b3 <scene_node_update_iterator>, user_data=0x7fffffffa030, lx=0, ly=0) at ../types/scene/wlr_scene.c:264
        scene_tree = 0x555555f43fa0
        child = 0x555555f99830
        node_box = {x = 667, y = 0, width = 1434366352, height = 21845}
#9  0x00007ffff7f9d46c in _scene_nodes_in_box
    (node=0x5555557eb190, box=0x7fffffffa040, iterator=0x7ffff7f9e8b3 <scene_node_update_iterator>, user_data=0x7fffffffa030, lx=0, ly=0) at ../types/scene/wlr_scene.c:264
        scene_tree = 0x5555557eb190
        child = 0x555555f43fa0
        node_box = {x = -24624, y = 32767, width = 1434366352, height = 21845}
#10 0x00007ffff7f9d599 in scene_nodes_in_box
    (node=0x5555557eb190, box=0x7fffffffa040, iterator=0x7ffff7f9e8b3 <scene_node_update_iterator>, user_data=0x7fffffffa030)
    at ../types/scene/wlr_scene.c:292
        x = 0
        y = 0
--Type <RET> for more, q to quit, c to continue without paging--
#11 0x00007ffff7f9ed2b in scene_update_region (scene=0x5555557eb190, update_region=0x7fffffffa0c0) at ../types/scene/wlr_scene.c:784
        visible = {extents = {x1 = 0, y1 = 0, x2 = 703, y2 = 482}, data = 0x555555f892f0}
        region_box = 0x7fffffffa0c0
        data = {visible = 0x7fffffffa010, update_region = 0x7fffffffa0c0, update_box = {x = 0, y = 0, width = 703, height = 482}, outputs = 0x5555557eb210, calculate_visibility = true, restack_above = 0x0}
#12 0x00007ffff7f9ee5f in scene_node_update (node=0x555555f99290, damage=0x7fffffffa110) at ../types/scene/wlr_scene.c:819
        scene = 0x5555557eb190
        x = 0
        y = 0
        visible = {extents = {x1 = -24344, y1 = 32767, x2 = -24256, y2 = 32767}, data = 0x7f01f79cec10}
        update_region = {extents = {x1 = 0, y1 = 0, x2 = 703, y2 = 482}, data = 0x5555560cec80}
#13 0x00007ffff7fa1a14 in wlr_scene_node_set_enabled (node=0x555555f99290, enabled=true) at ../types/scene/wlr_scene.c:1664
        x = 0
        y = 0
        visible = {extents = {x1 = 0, y1 = 0, x2 = 0, y2 = 0}, data = 0x7ffff79cec10}
#14 0x00007ffff7d895fe in wl_signal_emit_mutable () at /usr/lib/libwayland-server.so.0
#15 0x00007ffff7e3fa10 in ??? () at /usr/lib/libwlroots-0.20.so
#16 0x00007ffff752843e in ??? () at /usr/lib/libffi.so.8
#17 0x00007ffff7524a5d in ??? () at /usr/lib/libffi.so.8
#18 0x00007ffff75277ce in ffi_call () at /usr/lib/libffi.so.8
#19 0x00007ffff7d87240 in ??? () at /usr/lib/libwayland-server.so.0
#20 0x00007ffff7d8d374 in ??? () at /usr/lib/libwayland-server.so.0
#21 0x00007ffff7d8b872 in wl_event_loop_dispatch () at /usr/lib/libwayland-server.so.0
#22 0x00007ffff7d8d987 in wl_display_run () at /usr/lib/libwayland-server.so.0
#23 0x000055555555a845 in main (argc=3, argv=0x7fffffffad48) at ../tinywl/tinywl.c:1251
        startup_cmd = 0x7fffffffb55b "foot"
        c = -1
        server = {wl_display = 0x55555556b790, backend = 0x55555556b980, renderer = 0x55555581fba0, allocator = 0x555555ddb060, scene = 0x5555557eb190, scene_layout = 0x555555f43ea0, layers = {bottom_layer = 0x555555f29cc0, blur_layer = 0x555555f43f10, toplevel_layer --Type <RET> for more, q to quit, c to continue without paging--
= 0x555555f43fa0}, xdg_shell = 0x555555dda340, new_xdg_toplevel = {link = {prev = 0x555555dda388, next = 0x555555dda388}, notify = 0x555555559902 <server_new_xdg_toplevel>}, new_xdg_popup = {link = {prev = 0x555555dda398, next = 0x555555dda398}, notify = 0x555555559f07 <server_new_xdg_popup>}, toplevels = {prev = 0x7fffffffaa90, next = 0x7fffffffaa90}, cursor = 0x555555f44150, cursor_mgr = 0x555555e0ac50, cursor_motion = {link = {prev = 0x555555f44168, next = 0x555555f44168}, notify = 0x555555558494 <server_cursor_motion>}, cursor_motion_absolute = {link = {prev = 0x555555f44178, next = 0x555555f44178}, notify = 0x55555555850c <server_cursor_motion_absolute>}, cursor_button = {link = {prev = 0x555555f44188, next = 0x555555f44188}, notify = 0x555555558584 <server_cursor_button>}, cursor_axis = {link = {prev = 0x555555f44198, next = 0x555555f44198}, notify = 0x555555558669 <server_cursor_axis>}, cursor_frame = {link = {prev = 0x555555f441a8, next = 0x555555f441a8}, notify = 0x5555555586d7 <server_cursor_frame>}, seat = 0x555555f443d0, new_input = {link = {prev = 0x55555556b9a0, next = 0x55555556b9a0}, notify = 0x555555557e23 <server_new_input>}, request_cursor = {link = {prev = 0x555555f44708, next = 0x555555f44708}, notify = 0x555555557ebf <seat_request_cursor>}, request_set_selection = {link = {prev = 0x555555f44718, next = 0x555555f44718}, notify = 0x555555557f34 <seat_request_set_selection>}, keyboards = {prev = 0x555555f44800, next = 0x555555f44800}, cursor_mode = TINYWL_CURSOR_PASSTHROUGH, grabbed_toplevel = 0x0, grab_x = 0, grab_y = 0, grab_geobox = {x = 0, y = 0, width = 0, height = 0}, resize_edges = 0, output_layout = 0x555555f43e30, outputs = {prev = 0x55555601f390, next = 0x55555601f390}, new_output = {link = {prev = 0x55555556b9b0, next = 0x55555556b9b0}, notify = 0x555555558fc5 <server_new_output>}}
        bottom_rect_color = {1, 1, 1, 1}
        top_rect_color = {1, 0, 0, 1}
        rect = 0x555555f44030
        socket = 0x5555557ebcd9 "wayland-1"
``