### PR TITLE
vulkan: fix rects with clipped_region rendering as solid quads

### DIFF
--- a/render/vulkan/pass.c
+++ b/render/vulkan/pass.c
@@ -235,6 +235,11 @@ static void vk_render_pass_add_rect(struct fx_render_pass *fx_pass,
 			pixman_region32_init_rect(&clip_region, box.x, box.y, box.width, box.height);
 		}
 		apply_clip_region(&clip_region, clipped_region_box, clipped_region_corners);
+		pixman_region32_intersect(&clip_region, &clip_region, &clip);
+
+		int scissor_rects_len;
+		const pixman_box32_t *scissor_rects =
+			pixman_region32_rectangles(&clip_region, &scissor_rects_len);
 
 		struct vk_vert_pcr_data vert_pcr_data = {
 			.uv_off = { 0, 0 },
@@ -273,9 +278,9 @@ static void vk_render_pass_add_rect(struct fx_render_pass *fx_pass,
 				sizeof(vert_pcr_data),
 				sizeof(quad_pcr_data), &quad_pcr_data);
 
-		for (int i = 0; i < clip_rects_len; i++) {
+		for (int i = 0; i < scissor_rects_len; i++) {
 			VkRect2D rect;
-			convert_pixman_box_to_vk_rect(&clip_rects[i], &rect);
+			convert_pixman_box_to_vk_rect(&scissor_rects[i], &rect);
 			vkCmdSetScissor(cb, 0, 1, &rect);
 			vkCmdDraw(cb, 4, 1, 0, 0);
 		}

--- a/types/scene/wlr_scene.c
+++ b/types/scene/wlr_scene.c
@@ -2031,7 +2031,24 @@ static void scene_entry_render(struct render_list_entry *entry, const struct ren
 
 		if (data->fx_pass == NULL || (fx_corner_radii_is_empty(&rect_corners)
 					&& wlr_box_empty(&rect_options.clipped_region.area))) {
+			// The base renderer has no clipped_region support: punch the
+			// clipped area out of the clip region so the rect doesn't
+			// cover the nodes it is meant to frame.
+			struct wlr_box *hole = &rect_options.clipped_region.area;
+			pixman_region32_t clip_minus_hole;
+			pixman_region32_init(&clip_minus_hole);
+			if (!wlr_box_empty(hole)) {
+				pixman_region32_copy(&clip_minus_hole, &render_region);
+				pixman_region32_t hole_region;
+				pixman_region32_init_rect(&hole_region, hole->x, hole->y,
+						hole->width, hole->height);
+				pixman_region32_subtract(&clip_minus_hole,
+						&clip_minus_hole, &hole_region);
+				pixman_region32_fini(&hole_region);
+				rect_options.base.clip = &clip_minus_hole;
+			}
 			wlr_render_pass_add_rect(data->render_pass, &rect_options.base);
+			pixman_region32_fini(&clip_minus_hole);
 		} else {
 			fx_render_pass_add_rect(data->fx_pass, &rect_options);
 		}


### PR DESCRIPTION
Two fixes for `wlr_scene_rect` nodes with a `clipped_region` (the pattern compositors use to draw borders as one rect with the interior clipped out). On the vulkan branch both the fallback path and the vulkan render pass draw such rects as full solid quads, covering everything inside the border.

Symptom as seen in mango (scenefx_init + `WLR_RENDERER=vulkan`, where FX renderer init falls back to base wlroots rendering): the compositor raises the border rect above unfocused clients, so every unfocused window renders as a solid border-colored slab.

**scene: honor rect clipped_region when falling back to base renderer**
When `fx_pass == NULL` (unsupported renderer / fallback mode), `wlr_render_pass_add_rect()` is called with options that have no clipped_region support, so the clipped interior is ignored. Punch the clipped area out of the clip region with pixman before the fallback draw. Corner radii of the clipped region are ignored here (base renderer can't round), which matches the rest of the fallback path.

**vulkan: scissor rect draws with the clipped_region punched out**
`vk_render_pass_add_rect()` computes the punched clip region via `apply_clip_region()` but never uses the result — the draw loop scissors with the original unpunched rects, so the interior is filled and only the shader's corner refinement runs. Intersect the punched region with the pass clip region and scissor with that, matching the gles2 pass.

Tested: first commit verified on a live compositor (mango, vulkan renderer fallback mode) and builds clean with `-Drenderers=gles2` against stock wlroots 0.20. The second commit I could not compile here since wlroots-vkfx isn't public — it only touches the scissor rect source, but please give it a build check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)