### PR TITLE
blur: use a normal transform when blurring offscreen buffers

### DIFF
--- a/render/fx_renderer/fx_pass.c
+++ b/render/fx_renderer/fx_pass.c
@@ -994,12 +994,11 @@ static struct fx_framebuffer *get_main_buffer_blur(struct fx_gles_render_pass *p
 		return NULL;
 	}
 	fx_options->blur_data = &blur_data;
+	fx_options->tex_options.base.transform = WL_OUTPUT_TRANSFORM_NORMAL;
 
 	pixman_region32_t damage;
 	pixman_region32_init(&damage);
 	pixman_region32_copy(&damage, fx_options->tex_options.base.clip);
-	wlr_region_transform(&damage, &damage, fx_options->tex_options.base.transform,
-			buffer_bounds.width, buffer_bounds.height);
 
 	wlr_region_expand(&damage, &damage, blur_data_calc_size(&blur_data));
 	// Make sure that the region doesn't expand past the buffer bounds


### PR DESCRIPTION
I encountered #197 while debugging some issues with my configuration; Claude found this fix and it seems to have fixed the issue on my system and I haven't noticed any regressions so far. Thank you!

<br>

`get_main_buffer_blur()` only samples and writes offscreen framebuffers, which are always in output buffer orientation. It read `tex_options.base.transform`, which since #154 carries the transparency mask buffer's transform composed with the output transform. On a rotated output that is 90 or 270, and it fed two things: `wlr_region_transform()` on a clip region already converted to buffer coordinates, and the `set_tex_matrix()` call in every downscale and upscale pass. The blur passes then sampled and wrote the wrong part of the buffer.

Forcing the transform to normal for the whole function covers both uses. Both callers pass a copy of the options struct, so the transform needed afterwards to draw the stencil mask is untouched. This is the same thing #154 already does before the final draw, just early enough for the blur passes to get it too.

Closes #197.

## Testing

On the setup from #197, rofi's backdrop now shows the windows behind it rather than the wallpaper, and the blur stays confined to the panel. An unrotated output on the same machine is unchanged.