### PR TITLE
blur: clip damage compensation to the output, fixing screencast crashes

### DIFF
--- a/types/scene/wlr_scene.c
+++ b/types/scene/wlr_scene.c
@@ -2920,6 +2920,12 @@ static bool apply_blur_region(struct wlr_scene_node *node, struct blur_data *blu
 	pixman_region32_t intersection;
 	pixman_region32_init(&intersection);
 	if (pixman_region32_intersect(&intersection, &expanded_damage, &node_visible_region)) {
+		struct wlr_output *output = render_data->output->output;
+		pixman_region32_intersect_rect(&intersection, &intersection,
+			0, 0, output->width, output->height);
+	}
+
+	if (!pixman_region32_empty(&intersection)) {
 		should_compensate_blur = true;
 
 		// Expand the render damage to re-render surrounding blur nodes


### PR DESCRIPTION
I encountered https://github.com/wlrfx/scenefx/issues/198 while debugging some issues with my configuration; Claude found this fix and it seems to have fixed the issue on my system and I haven't noticed any regressions so far. Thank you!

<br>

`apply_blur_region()` unions the blur node's visible region, intersected with the expanded frame damage, into both `render_data->damage` and `output_state->damage`.

`node->visible` is in layout coordinates, so a node straddling two outputs reaches outside the output being rendered — negative once translated to output-relative coordinates just above. `render_data->damage` gets clipped to the output later in `scene_output_build_state()`, but `output_state->damage` never is, so those rectangles are published on commit. wlroots forwards them to ext-image-copy-capture sessions, where negative coordinates are a fatal protocol error.

Clip the intersection to the output before publishing it. Damage outside the output can't be rendered into its buffer, so nothing is lost.

The emptiness check is separate: `pixman_region32_intersect()` returns whether the operation succeeded, not whether the result is non-empty, so the old condition was effectively always true. Clipping can now genuinely empty the region, so `should_compensate_blur` needs the real check.

Closes #198

## Testing

Dragging a window across the boundary between my two outputs no longer ends the screencast. Instrumenting xdg-desktop-portal-wlr to log the damage it receives shows nothing arriving outside the output after this change, where before it was every frame of the drag. I have been running it since, with no blur artifacts at the output edges or across the seam.