### PR TITLE
vulkan: implement blur

### DIFF
--- a/include/render/vulkan/pipeline.h
+++ b/include/render/vulkan/pipeline.h
@@ -14,6 +14,9 @@ struct vk_pipeline {
 
 struct vk_pipelines {
 	struct vk_pipeline_quad *quad;
+	struct vk_pipeline_blur *blur1;
+	struct vk_pipeline_blur *blur2;
+	struct vk_pipeline_blur *blur_effects;
 };
 
 void vk_pipelines_init(struct vk_renderer *renderer, struct vk_render_setup *setup,

--- a/include/render/vulkan/shaders.h
+++ b/include/render/vulkan/shaders.h
@@ -66,4 +66,41 @@ struct vk_pipeline *get_vk_quad_pipeline(struct vk_pipeline_quad *quad,
 
 bool vk_shader_info_create_quad(struct vk_renderer *renderer);
 
+///
+/// Blur
+///
+
+// Field order matches the shader: the vec2 comes first so it keeps its 8 byte
+// alignment without needing explicit padding.
+struct vk_frag_blur_pcr_data {
+	float halfpixel[2];
+	float radius;
+};
+
+struct vk_frag_blur_effects_pcr_data {
+	float brightness;
+	float contrast;
+	float saturation;
+	float noise;
+};
+
+struct vk_pipeline_blur {
+	struct vk_pipeline pipeline;
+};
+
+// Shared by blur1/blur2/blur_effects: a single combined image sampler at
+// binding 0. Structurally identical to the layout wlroots uses for its texture
+// descriptor sets, so descriptor sets obtained via
+// wlr_vk_render_pass_get_texture_ds() are layout-compatible with these pipelines.
+VkDescriptorSetLayout vk_get_tex_ds_layout(struct vk_renderer *renderer);
+
+bool vk_shader_info_create_blur1(struct vk_renderer *renderer);
+bool vk_shader_info_create_blur2(struct vk_renderer *renderer);
+bool vk_shader_info_create_blur_effects(struct vk_renderer *renderer);
+
+bool create_vk_blur_pipelines(struct vk_renderer *renderer, struct vk_render_setup *setup,
+		struct vk_pipeline_blur **out_blur1, struct vk_pipeline_blur **out_blur2,
+		struct vk_pipeline_blur **out_blur_effects);
+void delete_vk_blur_pipelines(struct vk_renderer *renderer, struct vk_pipeline_blur *blur);
+
 #endif // !_RENDERER_VULKAN_SHADERS_H

--- a/include/render/vulkan/shaders.h
+++ b/include/render/vulkan/shaders.h
@@ -86,6 +86,10 @@ struct vk_frag_blur_effects_pcr_data {
 
 struct vk_pipeline_blur {
 	struct vk_pipeline pipeline;
+	// Layout of the shader this pipeline was created from. The blur layouts
+	// are currently identical, so binding through any of them happens to
+	// work, but that is not something to rely on.
+	VkPipelineLayout pipeline_layout;
 };
 
 // Sampling path for the blur passes: a single combined image sampler at

--- a/include/render/vulkan/shaders.h
+++ b/include/render/vulkan/shaders.h
@@ -88,11 +88,15 @@ struct vk_pipeline_blur {
 	struct vk_pipeline pipeline;
 };
 
-// Shared by blur1/blur2/blur_effects: a single combined image sampler at
-// binding 0. Structurally identical to the layout wlroots uses for its texture
-// descriptor sets, so descriptor sets obtained via
-// wlr_vk_render_pass_get_texture_ds() are layout-compatible with these pipelines.
+// Sampling path for the blur passes: a single combined image sampler at
+// binding 0 using our own immutable LINEAR/CLAMP_TO_EDGE sampler.
+// NOT interchangeable with wlroots' texture descriptor sets - its layout
+// declares a different immutable sampler, and Vulkan only considers layouts
+// compatible when identically defined.
 VkDescriptorSetLayout vk_get_tex_ds_layout(struct vk_renderer *renderer);
+VkDescriptorSet vk_tex_ds_create(struct vk_renderer *renderer, VkImageView view);
+void vk_tex_ds_destroy(struct vk_renderer *renderer, VkDescriptorSet ds);
+void vk_tex_ds_layout_destroy(struct vk_renderer *renderer);
 
 bool vk_shader_info_create_blur1(struct vk_renderer *renderer);
 bool vk_shader_info_create_blur2(struct vk_renderer *renderer);

--- a/include/render/vulkan/vulkan.h
+++ b/include/render/vulkan/vulkan.h
@@ -107,6 +107,14 @@ struct vk_renderer {
 		VkShaderModule vert;
 
 		struct vk_shader_info quad;
+
+		// Descriptor set layout shared by every texture-sampling shader below.
+		VkDescriptorSetLayout tex_ds_layout;
+
+		struct vk_shader_info blur1;
+		struct vk_shader_info blur2;
+		struct vk_shader_info blur_effects;
+
 		// TODO: more shaders
 		// struct quad_grad_shader quad_grad;
 		// struct quad_grad_round_shader quad_grad_round;
@@ -116,9 +124,6 @@ struct vk_renderer {
 		// struct tex_shader tex_ext;
 		//
 		// struct box_shadow_shader box_shadow;
-		// struct blur_shader blur1;
-		// struct blur_shader blur2;
-		// struct blur_effects_shader blur_effects;
 	} shader_info;
 
 	struct wl_list render_setups; // struct vk_render_setup.link

--- a/include/render/vulkan/vulkan.h
+++ b/include/render/vulkan/vulkan.h
@@ -166,6 +166,16 @@ struct vk_renderer {
 	VkRenderPass effect_render_pass;
 	struct vk_effect_image effect_images[VK_EFFECT_IMAGE_COUNT];
 
+	// Holds a copy of the frame's pixels in the blur padding ring, taken before
+	// the frame renders and pasted back afterwards. Transfer-only: no
+	// framebuffer or descriptor set, since nothing ever draws with it.
+	struct {
+		VkImage image;
+		VkDeviceMemory memory;
+		uint32_t width, height;
+		bool initialised;
+	} saved_pixels;
+
 	// Cached sampler descriptor set for the wlroots blend image, rebuilt only
 	// when the underlying image view changes.
 	VkDescriptorSet blend_ds;
@@ -177,6 +187,11 @@ bool vk_effect_images_ensure(struct vk_renderer *renderer,
 void vk_effect_images_finish(struct vk_renderer *renderer);
 /** Barrier the effect image into COLOR_ATTACHMENT_OPTIMAL ready to be drawn to. */
 void vk_effect_image_prepare_target(VkCommandBuffer cb, struct vk_effect_image *img);
+
+/** (Re)create the blur-padding snapshot image at the given size. */
+bool vk_saved_pixels_ensure(struct vk_renderer *renderer,
+	uint32_t width, uint32_t height);
+void vk_saved_pixels_finish(struct vk_renderer *renderer);
 VkDescriptorSet vk_get_blend_ds(struct vk_renderer *renderer, VkImageView view);
 
 /** Index of a memory type satisfying props, or -1. */

--- a/include/render/vulkan/vulkan.h
+++ b/include/render/vulkan/vulkan.h
@@ -108,8 +108,15 @@ struct vk_renderer {
 
 		struct vk_shader_info quad;
 
-		// Descriptor set layout shared by every texture-sampling shader below.
+		// Sampling path owned by scenefx. The blur passes sample our own
+		// offscreen images rather than wlr_textures, so we cannot reuse
+		// wlroots' texture descriptor sets: its layout declares an immutable
+		// sampler, and Vulkan only treats layouts as compatible when they are
+		// identically defined, immutable samplers included.
+		// Dual-Kawase also depends on bilinear taps, hence LINEAR/CLAMP_TO_EDGE.
+		VkSampler tex_sampler;
 		VkDescriptorSetLayout tex_ds_layout;
+		VkDescriptorPool tex_ds_pool;
 
 		struct vk_shader_info blur1;
 		struct vk_shader_info blur2;

--- a/include/render/vulkan/vulkan.h
+++ b/include/render/vulkan/vulkan.h
@@ -83,6 +83,28 @@ struct fx_render_pass *vk_render_pass_init(struct fx_renderer *fx_renderer,
 		struct wlr_render_pass *render_pass, struct wlr_buffer *wlr_buffer,
 		struct wlr_output *output);
 
+// Two targets are enough: the dual-Kawase chain only ever ping-pongs between a
+// source and a destination.
+#define VK_EFFECT_IMAGE_COUNT 2
+
+/**
+ * Offscreen colour target for the blur chain. Full output size: the dual-Kawase
+ * down/up scaling is expressed by shrinking the scissor rather than the image,
+ * matching the GLES2 implementation (and what blur1.frag's `uv * 2.0` expects).
+ */
+struct vk_effect_image {
+	VkImage image;
+	VkDeviceMemory memory;
+	VkImageView view;
+	VkFramebuffer framebuffer;
+	VkDescriptorSet ds;
+	uint32_t width, height;
+	// Tracked so the barrier before each use knows the source layout. The scene
+	// render pass declares finalLayout SHADER_READ_ONLY_OPTIMAL, so after any
+	// use the image sits there; before first use it is still UNDEFINED.
+	VkImageLayout layout;
+};
+
 struct vk_render_setup {
 	struct wl_list link; // vk_renderer.render_setups
 	VkRenderPass render_pass;
@@ -135,7 +157,31 @@ struct vk_renderer {
 
 	struct wl_list render_setups; // struct vk_render_setup.link
 	struct wl_list buffers; // vk_buffer.link
+
+	// Ping-pong render targets for the blur chain. Their framebuffers are built
+	// against the *scene* render pass rather than a private one: Vulkan only
+	// treats render passes as compatible when they are identical apart from a
+	// short exemption list that does NOT include subpass dependencies, so a
+	// bespoke pass would make the blur pipelines unusable. See effects.c.
+	VkRenderPass effect_render_pass;
+	struct vk_effect_image effect_images[VK_EFFECT_IMAGE_COUNT];
+
+	// Cached sampler descriptor set for the wlroots blend image, rebuilt only
+	// when the underlying image view changes.
+	VkDescriptorSet blend_ds;
+	VkImageView blend_ds_view;
 };
+
+bool vk_effect_images_ensure(struct vk_renderer *renderer,
+	VkRenderPass render_pass, uint32_t width, uint32_t height);
+void vk_effect_images_finish(struct vk_renderer *renderer);
+/** Barrier the effect image into COLOR_ATTACHMENT_OPTIMAL ready to be drawn to. */
+void vk_effect_image_prepare_target(VkCommandBuffer cb, struct vk_effect_image *img);
+VkDescriptorSet vk_get_blend_ds(struct vk_renderer *renderer, VkImageView view);
+
+/** Index of a memory type satisfying props, or -1. */
+int vk_find_mem_type(struct vk_renderer *renderer,
+	VkMemoryPropertyFlags props, uint32_t type_bits);
 
 struct fx_renderer *vk_renderer_create(struct wlr_renderer *wlr_renderer);
 

--- a/render/vulkan/effects.c
+++ b/render/vulkan/effects.c
@@ -1,0 +1,245 @@
+// Offscreen render targets for the blur ping-pong chain.
+//
+// These are plain VkImages owned by the renderer rather than wlr_buffers: blur
+// is recorded into the *same* command buffer as the scene (between
+// wlr_vk_render_pass_suspend/resume), so keeping the targets internal avoids
+// DMA-BUF import and any cross-command-buffer synchronisation.
+//
+// Format matches the scene render pass' colour attachment (the 16F blend
+// image). That is deliberate: a Vulkan pipeline may be used with any
+// "compatible" render pass, and compatibility only requires matching attachment
+// formats and subpass structure, so the blur pipelines built against the scene
+// pass can be reused here unchanged.
+
+#include <stdlib.h>
+#include <vulkan/vulkan_core.h>
+#include <wlr/render/vulkan.h>
+#include <wlr/util/log.h>
+
+#include "render/vulkan/shaders.h"
+#include "render/vulkan/vulkan.h"
+
+#define EFFECT_IMAGE_FORMAT VK_FORMAT_R16G16B16A16_SFLOAT
+
+// wlroots keeps its equivalent private, so scenefx needs its own.
+int vk_find_mem_type(struct vk_renderer *renderer,
+		VkMemoryPropertyFlags props, uint32_t type_bits) {
+	VkPhysicalDeviceMemoryProperties mem_props;
+	vkGetPhysicalDeviceMemoryProperties(renderer->physical_device, &mem_props);
+
+	for (uint32_t i = 0; i < mem_props.memoryTypeCount; i++) {
+		if (!(type_bits & (1u << i))) {
+			continue;
+		}
+		if ((mem_props.memoryTypes[i].propertyFlags & props) == props) {
+			return (int)i;
+		}
+	}
+	return -1;
+}
+
+static void effect_image_finish(struct vk_renderer *renderer,
+		struct vk_effect_image *img) {
+	VkDevice dev = renderer->device;
+	if (img->image == VK_NULL_HANDLE && img->ds == VK_NULL_HANDLE) {
+		return;
+	}
+	// These are only torn down on output reconfigure or shutdown, but the
+	// previous frame's command buffer may still reference the descriptor set,
+	// and freeing one that is in use is invalid. Rare enough that a full idle
+	// wait is cheaper than tracking per-frame lifetimes.
+	vkDeviceWaitIdle(dev);
+	if (img->ds != VK_NULL_HANDLE) {
+		vk_tex_ds_destroy(renderer, img->ds);
+	}
+	vkDestroyFramebuffer(dev, img->framebuffer, NULL);
+	vkDestroyImageView(dev, img->view, NULL);
+	vkDestroyImage(dev, img->image, NULL);
+	vkFreeMemory(dev, img->memory, NULL);
+	*img = (struct vk_effect_image){0};
+}
+
+static bool effect_image_init(struct vk_renderer *renderer,
+		struct vk_effect_image *img, uint32_t width, uint32_t height) {
+	VkDevice dev = renderer->device;
+	VkResult res;
+
+	VkImageCreateInfo img_info = {
+		.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+		.imageType = VK_IMAGE_TYPE_2D,
+		.format = EFFECT_IMAGE_FORMAT,
+		.mipLevels = 1,
+		.arrayLayers = 1,
+		.samples = VK_SAMPLE_COUNT_1_BIT,
+		.sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+		.tiling = VK_IMAGE_TILING_OPTIMAL,
+		.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+		.extent = (VkExtent3D){ width, height, 1 },
+		.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+	};
+	res = vkCreateImage(dev, &img_info, NULL, &img->image);
+	if (res != VK_SUCCESS) {
+		wlr_log(WLR_ERROR, "vkCreateImage failed for effect image");
+		goto error;
+	}
+
+	VkMemoryRequirements mem_reqs;
+	vkGetImageMemoryRequirements(dev, img->image, &mem_reqs);
+
+	int mem_type = vk_find_mem_type(renderer, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+		mem_reqs.memoryTypeBits);
+	if (mem_type < 0) {
+		wlr_log(WLR_ERROR, "no suitable memory type for effect image");
+		goto error;
+	}
+
+	VkMemoryAllocateInfo mem_info = {
+		.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+		.allocationSize = mem_reqs.size,
+		.memoryTypeIndex = mem_type,
+	};
+	res = vkAllocateMemory(dev, &mem_info, NULL, &img->memory);
+	if (res != VK_SUCCESS) {
+		wlr_log(WLR_ERROR, "vkAllocateMemory failed for effect image");
+		goto error;
+	}
+
+	res = vkBindImageMemory(dev, img->image, img->memory, 0);
+	if (res != VK_SUCCESS) {
+		wlr_log(WLR_ERROR, "vkBindImageMemory failed for effect image");
+		goto error;
+	}
+
+	VkImageViewCreateInfo view_info = {
+		.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+		.image = img->image,
+		.viewType = VK_IMAGE_VIEW_TYPE_2D,
+		.format = EFFECT_IMAGE_FORMAT,
+		.subresourceRange = (VkImageSubresourceRange){
+			.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+			.levelCount = 1,
+			.layerCount = 1,
+		},
+	};
+	res = vkCreateImageView(dev, &view_info, NULL, &img->view);
+	if (res != VK_SUCCESS) {
+		wlr_log(WLR_ERROR, "vkCreateImageView failed for effect image");
+		goto error;
+	}
+
+	VkFramebufferCreateInfo fb_info = {
+		.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
+		.renderPass = renderer->effect_render_pass,
+		.attachmentCount = 1,
+		.pAttachments = &img->view,
+		.width = width,
+		.height = height,
+		.layers = 1,
+	};
+	res = vkCreateFramebuffer(dev, &fb_info, NULL, &img->framebuffer);
+	if (res != VK_SUCCESS) {
+		wlr_log(WLR_ERROR, "vkCreateFramebuffer failed for effect image");
+		goto error;
+	}
+
+	img->ds = vk_tex_ds_create(renderer, img->view);
+	if (img->ds == VK_NULL_HANDLE) {
+		wlr_log(WLR_ERROR, "failed to create descriptor set for effect image");
+		goto error;
+	}
+
+	img->width = width;
+	img->height = height;
+	return true;
+
+error:
+	effect_image_finish(renderer, img);
+	return false;
+}
+
+bool vk_effect_images_ensure(struct vk_renderer *renderer,
+		VkRenderPass render_pass, uint32_t width, uint32_t height) {
+	if (render_pass == VK_NULL_HANDLE) {
+		return false;
+	}
+	// Framebuffers are tied to the render pass they were created with, so a
+	// different scene pass (e.g. after an output format change) invalidates them.
+	if (renderer->effect_render_pass != render_pass) {
+		vk_effect_images_finish(renderer);
+		renderer->effect_render_pass = render_pass;
+	}
+
+	for (size_t i = 0; i < VK_EFFECT_IMAGE_COUNT; i++) {
+		struct vk_effect_image *img = &renderer->effect_images[i];
+		if (img->image != VK_NULL_HANDLE &&
+				img->width == width && img->height == height) {
+			continue;
+		}
+		effect_image_finish(renderer, img);
+		if (!effect_image_init(renderer, img, width, height)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+void vk_effect_images_finish(struct vk_renderer *renderer) {
+	for (size_t i = 0; i < VK_EFFECT_IMAGE_COUNT; i++) {
+		effect_image_finish(renderer, &renderer->effect_images[i]);
+	}
+	// effect_render_pass is owned by wlroots (it is the scene pass); just forget it.
+	renderer->effect_render_pass = VK_NULL_HANDLE;
+	if (renderer->blend_ds != VK_NULL_HANDLE) {
+		vk_tex_ds_destroy(renderer, renderer->blend_ds);
+		renderer->blend_ds = VK_NULL_HANDLE;
+		renderer->blend_ds_view = VK_NULL_HANDLE;
+	}
+}
+
+VkDescriptorSet vk_get_blend_ds(struct vk_renderer *renderer, VkImageView view) {
+	if (view == VK_NULL_HANDLE) {
+		return VK_NULL_HANDLE;
+	}
+	// The blend image is recreated when the output is reconfigured, so cache
+	// the descriptor set and rebuild it only when the view actually changes.
+	if (renderer->blend_ds != VK_NULL_HANDLE && renderer->blend_ds_view == view) {
+		return renderer->blend_ds;
+	}
+	if (renderer->blend_ds != VK_NULL_HANDLE) {
+		// Same in-use hazard as effect_image_finish().
+		vkDeviceWaitIdle(renderer->device);
+		vk_tex_ds_destroy(renderer, renderer->blend_ds);
+	}
+	renderer->blend_ds = vk_tex_ds_create(renderer, view);
+	renderer->blend_ds_view = renderer->blend_ds != VK_NULL_HANDLE ? view : VK_NULL_HANDLE;
+	return renderer->blend_ds;
+}
+
+void vk_effect_image_prepare_target(VkCommandBuffer cb, struct vk_effect_image *img) {
+	VkImageMemoryBarrier barrier = {
+		.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+		.oldLayout = img->layout,
+		.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+		.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+		.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+		.image = img->image,
+		.subresourceRange = (VkImageSubresourceRange){
+			.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+			.levelCount = 1,
+			.layerCount = 1,
+		},
+		.srcAccessMask = img->layout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL ?
+			VK_ACCESS_SHADER_READ_BIT : 0,
+		.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+			VK_ACCESS_COLOR_ATTACHMENT_READ_BIT,
+	};
+
+	vkCmdPipelineBarrier(cb,
+		VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+		VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+		0, 0, NULL, 0, NULL, 1, &barrier);
+
+	// The scene render pass declares finalLayout SHADER_READ_ONLY_OPTIMAL, so
+	// once the upcoming pass ends the image will be samplable again.
+	img->layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+}

--- a/render/vulkan/effects.c
+++ b/render/vulkan/effects.c
@@ -243,3 +243,76 @@ void vk_effect_image_prepare_target(VkCommandBuffer cb, struct vk_effect_image *
 	// once the upcoming pass ends the image will be samplable again.
 	img->layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 }
+
+void vk_saved_pixels_finish(struct vk_renderer *renderer) {
+	if (renderer->saved_pixels.image == VK_NULL_HANDLE) {
+		return;
+	}
+	vkDeviceWaitIdle(renderer->device);
+	vkDestroyImage(renderer->device, renderer->saved_pixels.image, NULL);
+	vkFreeMemory(renderer->device, renderer->saved_pixels.memory, NULL);
+	renderer->saved_pixels.image = VK_NULL_HANDLE;
+	renderer->saved_pixels.memory = VK_NULL_HANDLE;
+	renderer->saved_pixels.initialised = false;
+}
+
+bool vk_saved_pixels_ensure(struct vk_renderer *renderer,
+		uint32_t width, uint32_t height) {
+	if (renderer->saved_pixels.image != VK_NULL_HANDLE &&
+			renderer->saved_pixels.width == width &&
+			renderer->saved_pixels.height == height) {
+		return true;
+	}
+	vk_saved_pixels_finish(renderer);
+
+	VkDevice dev = renderer->device;
+	// Transfer only: this image is never sampled or drawn to, it just holds a
+	// copy of the blend image's padding ring between save and apply.
+	VkImageCreateInfo img_info = {
+		.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+		.imageType = VK_IMAGE_TYPE_2D,
+		.format = EFFECT_IMAGE_FORMAT,
+		.mipLevels = 1,
+		.arrayLayers = 1,
+		.samples = VK_SAMPLE_COUNT_1_BIT,
+		.sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+		.tiling = VK_IMAGE_TILING_OPTIMAL,
+		.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+		.extent = (VkExtent3D){ width, height, 1 },
+		.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
+	};
+	if (vkCreateImage(dev, &img_info, NULL, &renderer->saved_pixels.image) != VK_SUCCESS) {
+		wlr_log(WLR_ERROR, "vkCreateImage failed for blur saved pixels");
+		return false;
+	}
+
+	VkMemoryRequirements mem_reqs;
+	vkGetImageMemoryRequirements(dev, renderer->saved_pixels.image, &mem_reqs);
+	int mem_type = vk_find_mem_type(renderer, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+		mem_reqs.memoryTypeBits);
+	if (mem_type < 0) {
+		goto error;
+	}
+
+	VkMemoryAllocateInfo mem_info = {
+		.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+		.allocationSize = mem_reqs.size,
+		.memoryTypeIndex = mem_type,
+	};
+	if (vkAllocateMemory(dev, &mem_info, NULL, &renderer->saved_pixels.memory) != VK_SUCCESS) {
+		goto error;
+	}
+	if (vkBindImageMemory(dev, renderer->saved_pixels.image,
+			renderer->saved_pixels.memory, 0) != VK_SUCCESS) {
+		goto error;
+	}
+
+	renderer->saved_pixels.width = width;
+	renderer->saved_pixels.height = height;
+	renderer->saved_pixels.initialised = false;
+	return true;
+
+error:
+	vk_saved_pixels_finish(renderer);
+	return false;
+}

--- a/render/vulkan/meson.build
+++ b/render/vulkan/meson.build
@@ -38,6 +38,7 @@ glslang_version = glslang_version_info.split('\n')[0].split(':')[-1]
 
 scenefx_files += files(
 	'buffer.c',
+	'effects.c',
 	'pass.c',
 	'pipeline.c',
 	'renderer.c',

--- a/render/vulkan/pass.c
+++ b/render/vulkan/pass.c
@@ -18,7 +18,7 @@
 #include "render/vulkan/vulkan.h"
 // #include "render/tracy.h"
 #include "scenefx/render/pass.h"
-// #include "scenefx/types/fx/blur_data.h"
+#include "scenefx/types/fx/blur_data.h"
 #include "util/matrix.h"
 
 ///
@@ -319,9 +319,265 @@ static void vk_render_pass_add_box_shadow(struct fx_render_pass *fx_pass,
 // 		struct fx_render_blur_pass_options *fx_options) {
 // }
 
+// Records one dual-Kawase step: samples src_ds into dst, over the scissor rects
+// in `region`. Runs inside its own effect render pass, so it must not be called
+// while the scene render pass is active.
+static void render_blur_step(struct vk_render_pass *pass,
+		struct vk_effect_image *dst, VkDescriptorSet src_ds,
+		struct vk_pipeline_blur *blur_pipeline, const pixman_region32_t *region,
+		float radius, bool downsample) {
+	struct vk_renderer *renderer = pass->vk_renderer;
+	VkCommandBuffer cb = pass->command_buffer;
+
+	int rects_len;
+	const pixman_box32_t *rects = pixman_region32_rectangles(region, &rects_len);
+	if (rects_len == 0) {
+		return;
+	}
+
+	// The scene render pass declares initialLayout COLOR_ATTACHMENT_OPTIMAL, so
+	// the target has to be moved there first (it is UNDEFINED before first use,
+	// SHADER_READ_ONLY_OPTIMAL after any previous chain step).
+	vk_effect_image_prepare_target(cb, dst);
+
+	VkRenderPassBeginInfo rp_info = {
+		.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
+		.renderArea = (VkRect2D){ .extent = { dst->width, dst->height } },
+		.clearValueCount = 0,
+		.renderPass = renderer->effect_render_pass,
+		.framebuffer = dst->framebuffer,
+	};
+	vkCmdBeginRenderPass(cb, &rp_info, VK_SUBPASS_CONTENTS_INLINE);
+	vkCmdSetViewport(cb, 0, 1, &(VkViewport){
+		.width = dst->width,
+		.height = dst->height,
+		.maxDepth = 1,
+	});
+
+	// common.vert emits a unit quad in [0,1]^2, so this maps it across the whole
+	// target in NDC. The scissor, not the geometry, selects the scaled region.
+	float proj[9] = {
+		2, 0, -1,
+		0, 2, -1,
+		0, 0,  1,
+	};
+	struct vk_vert_pcr_data vert_pcr_data = {
+		.uv_off = { 0, 0 },
+		.uv_size = { 1, 1 },
+	};
+	encode_proj_matrix(proj, vert_pcr_data.mat4);
+
+	// Downsample reads from a texture twice the size of the area being written
+	// (blur1.frag does uv * 2.0); upsample the other way around.
+	float scale = downsample ? 2.0f : 0.5f;
+	struct vk_frag_blur_pcr_data blur_pcr_data = {
+		.halfpixel = {
+			0.5f / (dst->width / scale),
+			0.5f / (dst->height / scale),
+		},
+		.radius = radius,
+	};
+
+	VkPipelineLayout layout = renderer->shader_info.blur1.pipeline_layout;
+	vkCmdBindPipeline(cb, VK_PIPELINE_BIND_POINT_GRAPHICS,
+		blur_pipeline->pipeline.pipeline);
+	vkCmdBindDescriptorSets(cb, VK_PIPELINE_BIND_POINT_GRAPHICS, layout,
+		0, 1, &src_ds, 0, NULL);
+	vkCmdPushConstants(cb, layout, VK_SHADER_STAGE_VERTEX_BIT,
+		0, sizeof(vert_pcr_data), &vert_pcr_data);
+	vkCmdPushConstants(cb, layout, VK_SHADER_STAGE_FRAGMENT_BIT,
+		sizeof(vert_pcr_data), sizeof(blur_pcr_data), &blur_pcr_data);
+
+	for (int i = 0; i < rects_len; i++) {
+		VkRect2D rect;
+		convert_pixman_box_to_vk_rect(&rects[i], &rect);
+		vkCmdSetScissor(cb, 0, 1, &rect);
+		vkCmdDraw(cb, 4, 1, 0, 0);
+	}
+
+	vkCmdEndRenderPass(cb);
+
+	// The scene pass' pipeline cache no longer reflects what is bound.
+	wlr_vk_render_pass_reset_pipeline(pass->fx_render_pass.render_pass);
+	pass->bound_pipeline = VK_NULL_HANDLE;
+}
+
 static void vk_render_pass_add_blur(struct fx_render_pass *fx_pass,
 		const struct fx_render_blur_pass_options *fx_options) {
-	// TODO:
+	struct vk_render_pass *pass = vk_get_render_pass(fx_pass);
+	struct vk_renderer *renderer = pass->vk_renderer;
+
+	struct blur_data blur_data =
+		blur_data_apply_strength(fx_options->blur_data, fx_options->blur_strength);
+	if (fx_options->blur_strength <= 0 || !is_scene_blur_enabled(&blur_data)) {
+		return;
+	}
+
+	struct wlr_buffer *buffer = pass->render_buffer->wlr_buffer;
+
+	// Only the two-pass (blending buffer) pathway can be suspended, which is
+	// also the pathway colour-managed/HDR output always uses. Elsewhere there is
+	// no intermediate image to sample, so blur is skipped rather than corrupting
+	// the frame.
+	VkImageView blend_view =
+		wlr_vk_render_pass_get_blend_image_view(fx_pass->render_pass);
+	if (blend_view == VK_NULL_HANDLE) {
+		return;
+	}
+	// Effect framebuffers must be built against the scene render pass so the
+	// blur pipelines stay compatible with them.
+	VkRenderPass scene_pass = wlr_vk_render_pass_get_render_pass(fx_pass->render_pass);
+	if (!vk_effect_images_ensure(renderer, scene_pass, buffer->width, buffer->height)) {
+		return;
+	}
+	VkDescriptorSet blend_ds = vk_get_blend_ds(renderer, blend_view);
+	if (blend_ds == VK_NULL_HANDLE) {
+		return;
+	}
+
+	struct vk_pipelines *pipelines = &pass->render_setup->vk_pipelines;
+	if (pipelines->blur1 == NULL || pipelines->blur2 == NULL ||
+			pipelines->blur_effects == NULL) {
+		return;
+	}
+
+	// Expand the damage so taps near the edge have valid neighbours, then clamp
+	// it to the buffer.
+	pixman_region32_t damage;
+	pixman_region32_init(&damage);
+	if (fx_options->tex_options.base.clip != NULL) {
+		pixman_region32_copy(&damage, fx_options->tex_options.base.clip);
+	} else {
+		pixman_region32_union_rect(&damage, &damage, 0, 0,
+			buffer->width, buffer->height);
+	}
+	wlr_region_expand(&damage, &damage, blur_data_calc_size(&blur_data));
+	pixman_region32_intersect_rect(&damage, &damage, 0, 0,
+		buffer->width, buffer->height);
+
+	if (!pixman_region32_not_empty(&damage)) {
+		pixman_region32_fini(&damage);
+		return;
+	}
+
+	if (!wlr_vk_render_pass_suspend(fx_pass->render_pass)) {
+		pixman_region32_fini(&damage);
+		return;
+	}
+
+	// The chain runs over the whole buffer rather than just the damaged part.
+	// The effect images are created with loadOp DONT_CARE, so any pixel the
+	// chain skips this frame holds undefined memory — and the composite below
+	// samples the effect image across the entire window, not just the damage.
+	// With a damage-sized chain that reads unwritten pixels as black, which
+	// shows up as black borders/blocks whenever damage is small (mouse moves).
+	//
+	// The GLES2 path can scope this to damage because it repairs the edges via
+	// save_blur_region()/apply_saved_blur_region(); those are still stubs here.
+	pixman_region32_t chain_region;
+	pixman_region32_init_rect(&chain_region, 0, 0, buffer->width, buffer->height);
+
+	pixman_region32_t scaled_damage;
+	pixman_region32_init(&scaled_damage);
+
+	// Ping-pong between the two effect images; the first read is the blend image
+	// holding everything drawn so far.
+	VkDescriptorSet src_ds = blend_ds;
+	size_t dst_index = 0;
+
+	for (int i = 0; i < blur_data.num_passes; i++) {
+		wlr_region_scale(&scaled_damage, &chain_region, 1.0f / (1 << (i + 1)));
+		render_blur_step(pass, &renderer->effect_images[dst_index], src_ds,
+			pipelines->blur1, &scaled_damage, blur_data.radius, true);
+		src_ds = renderer->effect_images[dst_index].ds;
+		dst_index ^= 1;
+	}
+
+	for (int i = blur_data.num_passes - 1; i >= 0; i--) {
+		wlr_region_scale(&scaled_damage, &chain_region, 1.0f / (1 << i));
+		render_blur_step(pass, &renderer->effect_images[dst_index], src_ds,
+			pipelines->blur2, &scaled_damage, blur_data.radius, false);
+		src_ds = renderer->effect_images[dst_index].ds;
+		dst_index ^= 1;
+	}
+
+	pixman_region32_fini(&scaled_damage);
+	pixman_region32_fini(&chain_region);
+
+	// dst_index was advanced past the last write; step back to the image that
+	// actually holds the blurred result.
+	size_t result_index = dst_index ^ 1;
+
+	if (!wlr_vk_render_pass_resume(fx_pass->render_pass)) {
+		pixman_region32_fini(&damage);
+		return;
+	}
+
+	// Composite the blurred image back into the scene with blur_effects, which
+	// samples texture(tex, uv) 1:1 and applies the brightness/contrast/
+	// saturation/noise stage — the same shader GLES2 finishes with.
+	//
+	// blur2 must NOT be used here even with zeroed constants: it is the upsample
+	// shader and does `suv = uv / 2.0`, which magnifies the top-left quarter of
+	// the blurred image over the whole region.
+	VkCommandBuffer cb = pass->command_buffer;
+	float proj[9] = {
+		2, 0, -1,
+		0, 2, -1,
+		0, 0,  1,
+	};
+	struct vk_vert_pcr_data vert_pcr_data = {
+		.uv_off = { 0, 0 },
+		.uv_size = { 1, 1 },
+	};
+	encode_proj_matrix(proj, vert_pcr_data.mat4);
+	struct vk_frag_blur_effects_pcr_data effects_pcr_data = {
+		.brightness = blur_data.brightness,
+		.contrast = blur_data.contrast,
+		.saturation = blur_data.saturation,
+		.noise = blur_data.noise,
+	};
+
+	VkPipelineLayout layout = renderer->shader_info.blur_effects.pipeline_layout;
+	VkDescriptorSet result_ds = renderer->effect_images[result_index].ds;
+	vkCmdBindPipeline(cb, VK_PIPELINE_BIND_POINT_GRAPHICS,
+		pipelines->blur_effects->pipeline.pipeline);
+	vkCmdBindDescriptorSets(cb, VK_PIPELINE_BIND_POINT_GRAPHICS, layout,
+		0, 1, &result_ds, 0, NULL);
+	vkCmdPushConstants(cb, layout, VK_SHADER_STAGE_VERTEX_BIT,
+		0, sizeof(vert_pcr_data), &vert_pcr_data);
+	vkCmdPushConstants(cb, layout, VK_SHADER_STAGE_FRAGMENT_BIT,
+		sizeof(vert_pcr_data), sizeof(effects_pcr_data), &effects_pcr_data);
+
+	// Composite only where the caller asked for blur. `damage` is deliberately
+	// wider (expanded so edge taps have neighbours) and must NOT be used here:
+	// painting the blurred image across the expanded area covers unrelated
+	// content, and because the next frame blurs the blend image again that
+	// feeds back into itself and smears the whole output.
+	pixman_region32_t composite_clip;
+	pixman_region32_init(&composite_clip);
+	if (fx_options->tex_options.base.clip != NULL) {
+		pixman_region32_copy(&composite_clip, fx_options->tex_options.base.clip);
+	} else {
+		pixman_region32_union_rect(&composite_clip, &composite_clip, 0, 0,
+			buffer->width, buffer->height);
+	}
+
+	int rects_len;
+	const pixman_box32_t *rects =
+		pixman_region32_rectangles(&composite_clip, &rects_len);
+	for (int i = 0; i < rects_len; i++) {
+		VkRect2D rect;
+		convert_pixman_box_to_vk_rect(&rects[i], &rect);
+		vkCmdSetScissor(cb, 0, 1, &rect);
+		vkCmdDraw(cb, 4, 1, 0, 0);
+	}
+
+	wlr_vk_render_pass_reset_pipeline(fx_pass->render_pass);
+	pass->bound_pipeline = VK_NULL_HANDLE;
+
+	pixman_region32_fini(&composite_clip);
+	pixman_region32_fini(&damage);
 }
 
 static bool vk_render_pass_add_optimized_blur(struct fx_render_pass *fx_pass,

--- a/render/vulkan/pass.c
+++ b/render/vulkan/pass.c
@@ -279,7 +279,11 @@ static void blur_padding_copy(struct fx_render_pass *fx_pass,
 		renderer->saved_pixels.initialised = true;
 	}
 
-	wlr_vk_render_pass_resume(fx_pass->render_pass);
+	if (!wlr_vk_render_pass_resume(fx_pass->render_pass)) {
+		wlr_log(WLR_ERROR, "Failed to resume the scene render pass after the "
+			"blur padding %s; subsequent commands are recorded outside it",
+			save ? "save" : "restore");
+	}
 }
 
 static void vk_render_pass_read_to_buffer(struct fx_render_pass *fx_pass,
@@ -528,7 +532,7 @@ static void render_blur_step(struct vk_render_pass *pass,
 		.radius = radius,
 	};
 
-	VkPipelineLayout layout = renderer->shader_info.blur1.pipeline_layout;
+	VkPipelineLayout layout = blur_pipeline->pipeline_layout;
 	vkCmdBindPipeline(cb, VK_PIPELINE_BIND_POINT_GRAPHICS,
 		blur_pipeline->pipeline.pipeline);
 	vkCmdBindDescriptorSets(cb, VK_PIPELINE_BIND_POINT_GRAPHICS, layout,
@@ -676,7 +680,7 @@ static void vk_render_pass_add_blur(struct fx_render_pass *fx_pass,
 		.noise = blur_data.noise,
 	};
 
-	VkPipelineLayout layout = renderer->shader_info.blur_effects.pipeline_layout;
+	VkPipelineLayout layout = pipelines->blur_effects->pipeline_layout;
 	VkDescriptorSet result_ds = renderer->effect_images[result_index].ds;
 	vkCmdBindPipeline(cb, VK_PIPELINE_BIND_POINT_GRAPHICS,
 		pipelines->blur_effects->pipeline.pipeline);

--- a/render/vulkan/pass.c
+++ b/render/vulkan/pass.c
@@ -126,26 +126,176 @@ static bool apply_clip_region(pixman_region32_t *clip_region,
 /// FX Render Pass implementation
 ///
 
+// Copies the blur padding ring between the blend image and our snapshot image.
+//
+// scenefx expands the frame's damage to include a ring around each blur node
+// (wlr_scene.c), snapshots those pixels before the frame renders, and pastes
+// them back afterwards. Without it, content that sits above a blur node leaks
+// into that node's blur on the next frame, because the blend image still holds
+// the previous frame's composited result wherever nothing was redrawn.
+//
+// vkCmdCopyImage cannot be recorded inside a render pass, so the scene pass is
+// suspended around the transfer and resumed afterwards.
+static void blur_padding_copy(struct fx_render_pass *fx_pass,
+		const pixman_region32_t *region, bool save) {
+	if (region == NULL || !pixman_region32_not_empty(region)) {
+		return;
+	}
+
+	struct vk_render_pass *pass = vk_get_render_pass(fx_pass);
+	struct vk_renderer *renderer = pass->vk_renderer;
+	struct wlr_buffer *buffer = pass->render_buffer->wlr_buffer;
+
+	VkImage blend = wlr_vk_render_pass_get_blend_image(fx_pass->render_pass);
+	if (blend == VK_NULL_HANDLE) {
+		return;
+	}
+	if (!vk_saved_pixels_ensure(renderer, buffer->width, buffer->height)) {
+		return;
+	}
+	// Nothing has been saved yet, so there is nothing to paste back.
+	if (!save && !renderer->saved_pixels.initialised) {
+		return;
+	}
+
+	int rects_len;
+	const pixman_box32_t *rects = pixman_region32_rectangles(region, &rects_len);
+	if (rects_len == 0) {
+		return;
+	}
+
+	if (!wlr_vk_render_pass_suspend(fx_pass->render_pass)) {
+		return;
+	}
+
+	VkCommandBuffer cb = pass->command_buffer;
+	VkImage src = save ? blend : renderer->saved_pixels.image;
+	VkImage dst = save ? renderer->saved_pixels.image : blend;
+
+	// The blend image sits in SHADER_READ_ONLY_OPTIMAL after the suspend; the
+	// snapshot image is UNDEFINED until first written, then TRANSFER_SRC.
+	// After any previous save the snapshot parks in TRANSFER_SRC; before the
+	// first one its contents are undefined.
+	VkImageLayout saved_old = renderer->saved_pixels.initialised ?
+		VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL : VK_IMAGE_LAYOUT_UNDEFINED;
+
+	VkImageSubresourceRange range = {
+		.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+		.levelCount = 1,
+		.layerCount = 1,
+	};
+	VkImageMemoryBarrier to_transfer[] = {
+		{
+			.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+			.oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+			.newLayout = save ? VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL :
+				VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+			.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+			.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+			.image = blend,
+			.subresourceRange = range,
+			.srcAccessMask = VK_ACCESS_SHADER_READ_BIT,
+			.dstAccessMask = save ? VK_ACCESS_TRANSFER_READ_BIT : VK_ACCESS_TRANSFER_WRITE_BIT,
+		},
+		{
+			.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+			.oldLayout = saved_old,
+			.newLayout = save ? VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL :
+				VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+			.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+			.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+			.image = renderer->saved_pixels.image,
+			.subresourceRange = range,
+			.srcAccessMask = 0,
+			.dstAccessMask = save ? VK_ACCESS_TRANSFER_WRITE_BIT : VK_ACCESS_TRANSFER_READ_BIT,
+		},
+	};
+	vkCmdPipelineBarrier(cb,
+		VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+		VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, NULL, 0, NULL, 2, to_transfer);
+
+	for (int i = 0; i < rects_len; i++) {
+		// Clamp to the image: scenefx bounds blur_padding_region by the output
+		// size, which is not always the render buffer size, and a copy that
+		// runs past the edge is invalid usage (and loses the device).
+		int32_t x1 = rects[i].x1 < 0 ? 0 : rects[i].x1;
+		int32_t y1 = rects[i].y1 < 0 ? 0 : rects[i].y1;
+		int32_t x2 = rects[i].x2 > (int32_t)renderer->saved_pixels.width ?
+			(int32_t)renderer->saved_pixels.width : rects[i].x2;
+		int32_t y2 = rects[i].y2 > (int32_t)renderer->saved_pixels.height ?
+			(int32_t)renderer->saved_pixels.height : rects[i].y2;
+
+		int32_t x = x1, y = y1;
+		int32_t w = x2 - x1;
+		int32_t h = y2 - y1;
+		if (w <= 0 || h <= 0) {
+			continue;
+		}
+		VkImageCopy copy = {
+			.srcSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 },
+			.dstSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 },
+			.srcOffset = { x, y, 0 },
+			.dstOffset = { x, y, 0 },
+			.extent = { w, h, 1 },
+		};
+		vkCmdCopyImage(cb,
+			src, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+			dst, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
+	}
+
+	// Blend goes back to being sampleable, which is the layout resume() expects
+	// to transition from; the snapshot parks in TRANSFER_SRC for the next apply.
+	VkImageMemoryBarrier from_transfer[] = {
+		{
+			.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+			.oldLayout = save ? VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL :
+				VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+			.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+			.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+			.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+			.image = blend,
+			.subresourceRange = range,
+			.srcAccessMask = save ? VK_ACCESS_TRANSFER_READ_BIT : VK_ACCESS_TRANSFER_WRITE_BIT,
+			.dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
+		},
+		{
+			.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+			.oldLayout = save ? VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL :
+				VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+			.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+			.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+			.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+			.image = renderer->saved_pixels.image,
+			.subresourceRange = range,
+			.srcAccessMask = save ? VK_ACCESS_TRANSFER_WRITE_BIT : VK_ACCESS_TRANSFER_READ_BIT,
+			.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+		},
+	};
+	vkCmdPipelineBarrier(cb, VK_PIPELINE_STAGE_TRANSFER_BIT,
+		VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_TRANSFER_BIT,
+		0, 0, NULL, 0, NULL, 2, from_transfer);
+
+	if (save) {
+		renderer->saved_pixels.initialised = true;
+	}
+
+	wlr_vk_render_pass_resume(fx_pass->render_pass);
+}
+
 static void vk_render_pass_read_to_buffer(struct fx_render_pass *fx_pass,
 		const pixman_region32_t *_region, struct wlr_buffer *dst_buffer,
 		struct wlr_buffer *src_buffer) {
-	// TODO:
+	// Unused by the Vulkan path: the blur padding snapshot is kept in a
+	// renderer-owned VkImage rather than a wlr_buffer, so save/apply below copy
+	// directly instead of going through this wlr_buffer-oriented entry point.
 }
 
 static void vk_render_pass_save_blur_region(struct fx_render_pass *fx_pass) {
-	// TODO:
-	// struct vk_render_pass *pass = vk_get_render_pass(fx_pass);
-	// vk_render_pass_read_to_buffer(fx_pass, &fx_pass->blur_padding_region,
-	// 		pass->vk_offscreen_buffers->blur_saved_pixels_buffer->wlr_buffer,
-	// 		pass->render_buffer->wlr_buffer);
+	blur_padding_copy(fx_pass, &fx_pass->blur_padding_region, true);
 }
 
 static void vk_render_pass_apply_saved_blur_region(struct fx_render_pass *fx_pass) {
-	// TODO:
-	// struct vk_render_pass *pass = vk_get_render_pass(fx_pass);
-	// vk_render_pass_read_to_buffer(fx_pass, &fx_pass->blur_padding_region,
-	// 		pass->render_buffer->wlr_buffer,
-	// 		pass->vk_offscreen_buffers->blur_saved_pixels_buffer->wlr_buffer);
+	blur_padding_copy(fx_pass, &fx_pass->blur_padding_region, false);
 }
 
 static void vk_render_pass_destroy(struct fx_render_pass *fx_pass) {
@@ -465,17 +615,6 @@ static void vk_render_pass_add_blur(struct fx_render_pass *fx_pass,
 		return;
 	}
 
-	// The chain runs over the whole buffer rather than just the damaged part.
-	// The effect images are created with loadOp DONT_CARE, so any pixel the
-	// chain skips this frame holds undefined memory — and the composite below
-	// samples the effect image across the entire window, not just the damage.
-	// With a damage-sized chain that reads unwritten pixels as black, which
-	// shows up as black borders/blocks whenever damage is small (mouse moves).
-	//
-	// The GLES2 path can scope this to damage because it repairs the edges via
-	// save_blur_region()/apply_saved_blur_region(); those are still stubs here.
-	pixman_region32_t chain_region;
-	pixman_region32_init_rect(&chain_region, 0, 0, buffer->width, buffer->height);
 
 	pixman_region32_t scaled_damage;
 	pixman_region32_init(&scaled_damage);
@@ -486,7 +625,7 @@ static void vk_render_pass_add_blur(struct fx_render_pass *fx_pass,
 	size_t dst_index = 0;
 
 	for (int i = 0; i < blur_data.num_passes; i++) {
-		wlr_region_scale(&scaled_damage, &chain_region, 1.0f / (1 << (i + 1)));
+		wlr_region_scale(&scaled_damage, &damage, 1.0f / (1 << (i + 1)));
 		render_blur_step(pass, &renderer->effect_images[dst_index], src_ds,
 			pipelines->blur1, &scaled_damage, blur_data.radius, true);
 		src_ds = renderer->effect_images[dst_index].ds;
@@ -494,7 +633,7 @@ static void vk_render_pass_add_blur(struct fx_render_pass *fx_pass,
 	}
 
 	for (int i = blur_data.num_passes - 1; i >= 0; i--) {
-		wlr_region_scale(&scaled_damage, &chain_region, 1.0f / (1 << i));
+		wlr_region_scale(&scaled_damage, &damage, 1.0f / (1 << i));
 		render_blur_step(pass, &renderer->effect_images[dst_index], src_ds,
 			pipelines->blur2, &scaled_damage, blur_data.radius, false);
 		src_ds = renderer->effect_images[dst_index].ds;
@@ -502,7 +641,6 @@ static void vk_render_pass_add_blur(struct fx_render_pass *fx_pass,
 	}
 
 	pixman_region32_fini(&scaled_damage);
-	pixman_region32_fini(&chain_region);
 
 	// dst_index was advanced past the last write; step back to the image that
 	// actually holds the blurred result.

--- a/render/vulkan/pipeline.c
+++ b/render/vulkan/pipeline.c
@@ -6,10 +6,15 @@ void vk_pipelines_init(struct vk_renderer *renderer, struct vk_render_setup *set
 	*out_pipelines = (struct vk_pipelines) {0};
 
 	create_vk_quad_pipelines(renderer, setup, &out_pipelines->quad);
+	create_vk_blur_pipelines(renderer, setup, &out_pipelines->blur1,
+			&out_pipelines->blur2, &out_pipelines->blur_effects);
 	// TODO: More shader pipelines
 }
 
 void vk_pipelines_destroy(struct vk_renderer *renderer, struct vk_pipelines *pipelines) {
 	delete_vk_quad_pipelines(renderer, pipelines->quad);
+	delete_vk_blur_pipelines(renderer, pipelines->blur1);
+	delete_vk_blur_pipelines(renderer, pipelines->blur2);
+	delete_vk_blur_pipelines(renderer, pipelines->blur_effects);
 	// TODO: More shader pipelines
 }

--- a/render/vulkan/renderer.c
+++ b/render/vulkan/renderer.c
@@ -184,6 +184,10 @@ static void renderer_destroy(struct fx_renderer *fx_renderer) {
 		vk_render_setup_destroy(vk_renderer, render_setup);
 	}
 
+	// Blur targets must go before the descriptor pool and layout in
+	// free_shaders(), since their descriptor sets are allocated from it.
+	vk_effect_images_finish(vk_renderer);
+
 	free_shaders(vk_renderer);
 
 	free(vk_renderer);

--- a/render/vulkan/renderer.c
+++ b/render/vulkan/renderer.c
@@ -16,6 +16,12 @@
 static inline void free_shaders(struct vk_renderer *vk_renderer) {
 	vk_shader_info_delete(vk_renderer, &vk_renderer->shader_info.quad);
 
+	vk_shader_info_delete(vk_renderer, &vk_renderer->shader_info.blur1);
+	vk_shader_info_delete(vk_renderer, &vk_renderer->shader_info.blur2);
+	vk_shader_info_delete(vk_renderer, &vk_renderer->shader_info.blur_effects);
+	// Must come after the pipeline layouts above, which reference this layout.
+	vk_tex_ds_layout_destroy(vk_renderer);
+
 	// TODO:
 	// push_fx_debug(vk_renderer);
 	// delete_quad_programs(&vk_renderer->shaders.quad);

--- a/render/vulkan/renderer.c
+++ b/render/vulkan/renderer.c
@@ -187,6 +187,7 @@ static void renderer_destroy(struct fx_renderer *fx_renderer) {
 	// Blur targets must go before the descriptor pool and layout in
 	// free_shaders(), since their descriptor sets are allocated from it.
 	vk_effect_images_finish(vk_renderer);
+	vk_saved_pixels_finish(vk_renderer);
 
 	free_shaders(vk_renderer);
 

--- a/render/vulkan/renderer.c
+++ b/render/vulkan/renderer.c
@@ -47,6 +47,20 @@ static bool link_shaders(struct vk_renderer *renderer) {
 		goto error;
 	}
 
+	// blur fragment shaders (dual-Kawase down/up plus the effects pass)
+	if (!vk_shader_info_create_blur1(renderer)) {
+		wlr_log(WLR_ERROR, "Could not link blur1 shader");
+		goto error;
+	}
+	if (!vk_shader_info_create_blur2(renderer)) {
+		wlr_log(WLR_ERROR, "Could not link blur2 shader");
+		goto error;
+	}
+	if (!vk_shader_info_create_blur_effects(renderer)) {
+		wlr_log(WLR_ERROR, "Could not link blur_effects shader");
+		goto error;
+	}
+
 	// if (!link_quad_programs(&vk_renderer->shaders.quad)) {
 	// 	wlr_log(WLR_ERROR, "Could not link quad shaders");
 	// 	goto error;

--- a/render/vulkan/shaders.c
+++ b/render/vulkan/shaders.c
@@ -426,7 +426,9 @@ static bool create_blur_shader_info(struct vk_renderer *renderer,
 			.stageFlags = VK_SHADER_STAGE_VERTEX_BIT,
 		},
 		{
-			.offset = pc_ranges[0].size,
+			// Must not be written as pc_ranges[0].size: reading the array
+			// while it is still being initialised is unspecified.
+			.offset = sizeof(struct vk_vert_pcr_data),
 			.size = frag_pcr_size,
 			.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
 		},
@@ -580,6 +582,7 @@ static struct vk_pipeline_blur *create_one_blur_pipeline(struct vk_renderer *ren
 		free(blur);
 		return NULL;
 	}
+	blur->pipeline_layout = shader->pipeline_layout;
 	return blur;
 }
 

--- a/render/vulkan/shaders.c
+++ b/render/vulkan/shaders.c
@@ -12,6 +12,9 @@
 // shaders
 #include "common.vert.h"
 #include "quad.frag.h"
+#include "blur1.frag.h"
+#include "blur2.frag.h"
+#include "blur_effects.frag.h"
 
 void vk_shader_info_delete(struct vk_renderer *renderer, struct vk_shader_info *shader_info) {
 	vkDestroyShaderModule(renderer->device, shader_info->shader_module, NULL);
@@ -248,4 +251,251 @@ bool vk_shader_info_create_quad(struct vk_renderer *renderer) {
 	}
 
 	return true;
+}
+
+///
+/// Blur
+///
+
+VkDescriptorSetLayout vk_get_tex_ds_layout(struct vk_renderer *renderer) {
+	if (renderer->shader_info.tex_ds_layout != VK_NULL_HANDLE) {
+		return renderer->shader_info.tex_ds_layout;
+	}
+
+	VkDescriptorSetLayoutBinding binding = {
+		.binding = 0,
+		.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+		.descriptorCount = 1,
+		.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
+	};
+	VkDescriptorSetLayoutCreateInfo info = {
+		.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+		.bindingCount = 1,
+		.pBindings = &binding,
+	};
+
+	VkResult res = vkCreateDescriptorSetLayout(renderer->device, &info, NULL,
+			&renderer->shader_info.tex_ds_layout);
+	if (res != VK_SUCCESS) {
+		wlr_vk_error("vkCreateDescriptorSetLayout (tex)", res);
+		return VK_NULL_HANDLE;
+	}
+	return renderer->shader_info.tex_ds_layout;
+}
+
+// Shared by all three blur shaders: one sampler set plus a vertex and a
+// fragment push constant range. `frag_pcr_size` is what differs between them.
+static bool create_blur_shader_info(struct vk_renderer *renderer,
+		struct vk_shader_info *shader, const uint32_t *spv, size_t spv_size,
+		size_t frag_pcr_size, const char *name) {
+	VkShaderModuleCreateInfo shader_info = {
+		.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,
+		.codeSize = spv_size,
+		.pCode = spv,
+	};
+	VkResult res = vkCreateShaderModule(renderer->device, &shader_info, NULL,
+			&shader->shader_module);
+	if (res != VK_SUCCESS) {
+		wlr_vk_error("Failed to create blur fragment shader module", res);
+		wlr_log(WLR_ERROR, "  shader: %s", name);
+		return false;
+	}
+
+	VkDescriptorSetLayout ds_layout = vk_get_tex_ds_layout(renderer);
+	if (ds_layout == VK_NULL_HANDLE) {
+		vkDestroyShaderModule(renderer->device, shader->shader_module, NULL);
+		return false;
+	}
+
+	VkPushConstantRange pc_ranges[] = {
+		{
+			.size = sizeof(struct vk_vert_pcr_data),
+			.stageFlags = VK_SHADER_STAGE_VERTEX_BIT,
+		},
+		{
+			.offset = pc_ranges[0].size,
+			.size = frag_pcr_size,
+			.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
+		},
+	};
+
+	VkPipelineLayoutCreateInfo pl_info = {
+		.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+		.setLayoutCount = 1,
+		.pSetLayouts = &ds_layout,
+		.pushConstantRangeCount = sizeof(pc_ranges) / sizeof(pc_ranges[0]),
+		.pPushConstantRanges = pc_ranges,
+	};
+
+	res = vkCreatePipelineLayout(renderer->device, &pl_info, NULL, &shader->pipeline_layout);
+	if (res != VK_SUCCESS) {
+		vkDestroyShaderModule(renderer->device, shader->shader_module, NULL);
+		wlr_vk_error("vkCreatePipelineLayout (blur)", res);
+		return false;
+	}
+
+	return true;
+}
+
+bool vk_shader_info_create_blur1(struct vk_renderer *renderer) {
+	return create_blur_shader_info(renderer, &renderer->shader_info.blur1,
+		blur1_frag_data, sizeof(blur1_frag_data),
+		sizeof(struct vk_frag_blur_pcr_data), "blur1");
+}
+
+bool vk_shader_info_create_blur2(struct vk_renderer *renderer) {
+	return create_blur_shader_info(renderer, &renderer->shader_info.blur2,
+		blur2_frag_data, sizeof(blur2_frag_data),
+		sizeof(struct vk_frag_blur_pcr_data), "blur2");
+}
+
+bool vk_shader_info_create_blur_effects(struct vk_renderer *renderer) {
+	return create_blur_shader_info(renderer, &renderer->shader_info.blur_effects,
+		blur_effects_frag_data, sizeof(blur_effects_frag_data),
+		sizeof(struct vk_frag_blur_effects_pcr_data), "blur_effects");
+}
+
+// The blur passes write into offscreen buffers and fully replace their
+// contents, so unlike the quad pipeline they disable blending.
+static bool create_pipeline_blur(struct vk_renderer *renderer, struct vk_render_setup *setup,
+		struct vk_shader_info *shader, struct vk_pipeline *variant) {
+	VkPipelineShaderStageCreateInfo stages[] = {
+		(VkPipelineShaderStageCreateInfo) {
+			.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+			.stage = VK_SHADER_STAGE_VERTEX_BIT,
+			.module = renderer->shader_info.vert,
+			.pName = "main",
+		},
+		(VkPipelineShaderStageCreateInfo) {
+			.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+			.stage = VK_SHADER_STAGE_FRAGMENT_BIT,
+			.module = shader->shader_module,
+			.pName = "main",
+		},
+	};
+
+	VkPipelineInputAssemblyStateCreateInfo assembly = {
+		.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
+		.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN,
+	};
+
+	VkPipelineRasterizationStateCreateInfo rasterization = {
+		.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
+		.polygonMode = VK_POLYGON_MODE_FILL,
+		.cullMode = VK_CULL_MODE_NONE,
+		.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE,
+		.lineWidth = 1.f,
+	};
+
+	VkPipelineColorBlendAttachmentState blend_attachment = {
+		.blendEnable = false,
+		.colorWriteMask =
+			VK_COLOR_COMPONENT_R_BIT |
+			VK_COLOR_COMPONENT_G_BIT |
+			VK_COLOR_COMPONENT_B_BIT |
+			VK_COLOR_COMPONENT_A_BIT,
+	};
+
+	VkPipelineColorBlendStateCreateInfo blend = {
+		.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,
+		.attachmentCount = 1,
+		.pAttachments = &blend_attachment,
+	};
+
+	VkPipelineMultisampleStateCreateInfo multisample = {
+		.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
+		.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT,
+	};
+
+	VkPipelineViewportStateCreateInfo viewport = {
+		.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO,
+		.viewportCount = 1,
+		.scissorCount = 1,
+	};
+
+	VkDynamicState dyn_states[] = {
+		VK_DYNAMIC_STATE_VIEWPORT,
+		VK_DYNAMIC_STATE_SCISSOR,
+	};
+	VkPipelineDynamicStateCreateInfo dynamic = {
+		.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO,
+		.pDynamicStates = dyn_states,
+		.dynamicStateCount = sizeof(dyn_states) / sizeof(dyn_states[0]),
+	};
+
+	VkPipelineVertexInputStateCreateInfo vertex = {
+		.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO,
+	};
+
+	VkGraphicsPipelineCreateInfo pinfo = {
+		.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
+		.layout = shader->pipeline_layout,
+		.renderPass = setup->render_pass,
+		.subpass = 0,
+		.stageCount = sizeof(stages) / sizeof(stages[0]),
+		.pStages = stages,
+
+		.pInputAssemblyState = &assembly,
+		.pRasterizationState = &rasterization,
+		.pColorBlendState = &blend,
+		.pMultisampleState = &multisample,
+		.pViewportState = &viewport,
+		.pDynamicState = &dynamic,
+		.pVertexInputState = &vertex,
+	};
+
+	VkPipelineCache cache = VK_NULL_HANDLE;
+	VkResult res = vkCreateGraphicsPipelines(renderer->device, cache, 1, &pinfo, NULL,
+			&variant->pipeline);
+	if (res != VK_SUCCESS) {
+		wlr_vk_error("failed to create blur pipeline:", res);
+		return false;
+	}
+
+	wl_list_insert(&setup->pipelines, &variant->link);
+	return true;
+}
+
+static struct vk_pipeline_blur *create_one_blur_pipeline(struct vk_renderer *renderer,
+		struct vk_render_setup *setup, struct vk_shader_info *shader) {
+	struct vk_pipeline_blur *blur = calloc(1, sizeof(*blur));
+	if (blur == NULL) {
+		return NULL;
+	}
+	blur->pipeline.pipeline = VK_NULL_HANDLE;
+	if (!create_pipeline_blur(renderer, setup, shader, &blur->pipeline)) {
+		free(blur);
+		return NULL;
+	}
+	return blur;
+}
+
+bool create_vk_blur_pipelines(struct vk_renderer *renderer, struct vk_render_setup *setup,
+		struct vk_pipeline_blur **out_blur1, struct vk_pipeline_blur **out_blur2,
+		struct vk_pipeline_blur **out_blur_effects) {
+	*out_blur1 = create_one_blur_pipeline(renderer, setup, &renderer->shader_info.blur1);
+	*out_blur2 = create_one_blur_pipeline(renderer, setup, &renderer->shader_info.blur2);
+	*out_blur_effects = create_one_blur_pipeline(renderer, setup,
+			&renderer->shader_info.blur_effects);
+
+	if (*out_blur1 == NULL || *out_blur2 == NULL || *out_blur_effects == NULL) {
+		wlr_log(WLR_ERROR, "Could not create blur shader pipelines");
+		delete_vk_blur_pipelines(renderer, *out_blur1);
+		delete_vk_blur_pipelines(renderer, *out_blur2);
+		delete_vk_blur_pipelines(renderer, *out_blur_effects);
+		*out_blur1 = *out_blur2 = *out_blur_effects = NULL;
+		return false;
+	}
+	return true;
+}
+
+void delete_vk_blur_pipelines(struct vk_renderer *renderer, struct vk_pipeline_blur *blur) {
+	if (blur == NULL) {
+		return;
+	}
+	if (blur->pipeline.pipeline != VK_NULL_HANDLE) {
+		vkDestroyPipeline(renderer->device, blur->pipeline.pipeline, NULL);
+		wl_list_remove(&blur->pipeline.link);
+	}
+	free(blur);
 }

--- a/render/vulkan/shaders.c
+++ b/render/vulkan/shaders.c
@@ -257,9 +257,35 @@ bool vk_shader_info_create_quad(struct vk_renderer *renderer) {
 /// Blur
 ///
 
+// Descriptor sets for the blur passes are allocated from this pool, in this
+// layout, and always sample through our own immutable sampler. Note this is
+// deliberately NOT compatible with wlroots' texture descriptor sets - see the
+// comment on tex_sampler in vulkan.h.
+#define VK_TEX_DS_POOL_SIZE 64
+
 VkDescriptorSetLayout vk_get_tex_ds_layout(struct vk_renderer *renderer) {
 	if (renderer->shader_info.tex_ds_layout != VK_NULL_HANDLE) {
 		return renderer->shader_info.tex_ds_layout;
+	}
+
+	VkSamplerCreateInfo sampler_info = {
+		.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,
+		.magFilter = VK_FILTER_LINEAR,
+		.minFilter = VK_FILTER_LINEAR,
+		.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST,
+		.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+		.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+		.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+		.maxAnisotropy = 1.f,
+		.minLod = 0.f,
+		.maxLod = 0.25f,
+		.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK,
+	};
+	VkResult res = vkCreateSampler(renderer->device, &sampler_info, NULL,
+			&renderer->shader_info.tex_sampler);
+	if (res != VK_SUCCESS) {
+		wlr_vk_error("vkCreateSampler (blur)", res);
+		return VK_NULL_HANDLE;
 	}
 
 	VkDescriptorSetLayoutBinding binding = {
@@ -267,6 +293,7 @@ VkDescriptorSetLayout vk_get_tex_ds_layout(struct vk_renderer *renderer) {
 		.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
 		.descriptorCount = 1,
 		.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
+		.pImmutableSamplers = &renderer->shader_info.tex_sampler,
 	};
 	VkDescriptorSetLayoutCreateInfo info = {
 		.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
@@ -274,13 +301,99 @@ VkDescriptorSetLayout vk_get_tex_ds_layout(struct vk_renderer *renderer) {
 		.pBindings = &binding,
 	};
 
-	VkResult res = vkCreateDescriptorSetLayout(renderer->device, &info, NULL,
+	res = vkCreateDescriptorSetLayout(renderer->device, &info, NULL,
 			&renderer->shader_info.tex_ds_layout);
 	if (res != VK_SUCCESS) {
+		vkDestroySampler(renderer->device, renderer->shader_info.tex_sampler, NULL);
+		renderer->shader_info.tex_sampler = VK_NULL_HANDLE;
 		wlr_vk_error("vkCreateDescriptorSetLayout (tex)", res);
 		return VK_NULL_HANDLE;
 	}
+
+	VkDescriptorPoolSize pool_size = {
+		.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+		.descriptorCount = VK_TEX_DS_POOL_SIZE,
+	};
+	VkDescriptorPoolCreateInfo pool_info = {
+		.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+		.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT,
+		.maxSets = VK_TEX_DS_POOL_SIZE,
+		.poolSizeCount = 1,
+		.pPoolSizes = &pool_size,
+	};
+	res = vkCreateDescriptorPool(renderer->device, &pool_info, NULL,
+			&renderer->shader_info.tex_ds_pool);
+	if (res != VK_SUCCESS) {
+		vkDestroyDescriptorSetLayout(renderer->device,
+				renderer->shader_info.tex_ds_layout, NULL);
+		renderer->shader_info.tex_ds_layout = VK_NULL_HANDLE;
+		vkDestroySampler(renderer->device, renderer->shader_info.tex_sampler, NULL);
+		renderer->shader_info.tex_sampler = VK_NULL_HANDLE;
+		wlr_vk_error("vkCreateDescriptorPool (tex)", res);
+		return VK_NULL_HANDLE;
+	}
+
 	return renderer->shader_info.tex_ds_layout;
+}
+
+VkDescriptorSet vk_tex_ds_create(struct vk_renderer *renderer, VkImageView view) {
+	VkDescriptorSetLayout layout = vk_get_tex_ds_layout(renderer);
+	if (layout == VK_NULL_HANDLE) {
+		return VK_NULL_HANDLE;
+	}
+
+	VkDescriptorSetAllocateInfo alloc_info = {
+		.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+		.descriptorPool = renderer->shader_info.tex_ds_pool,
+		.descriptorSetCount = 1,
+		.pSetLayouts = &layout,
+	};
+	VkDescriptorSet ds = VK_NULL_HANDLE;
+	VkResult res = vkAllocateDescriptorSets(renderer->device, &alloc_info, &ds);
+	if (res != VK_SUCCESS) {
+		wlr_vk_error("vkAllocateDescriptorSets (tex)", res);
+		return VK_NULL_HANDLE;
+	}
+
+	VkDescriptorImageInfo image_info = {
+		// sampler comes from the layout's immutable sampler
+		.imageView = view,
+		.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+	};
+	VkWriteDescriptorSet write = {
+		.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+		.dstSet = ds,
+		.dstBinding = 0,
+		.descriptorCount = 1,
+		.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+		.pImageInfo = &image_info,
+	};
+	vkUpdateDescriptorSets(renderer->device, 1, &write, 0, NULL);
+
+	return ds;
+}
+
+void vk_tex_ds_destroy(struct vk_renderer *renderer, VkDescriptorSet ds) {
+	if (ds == VK_NULL_HANDLE || renderer->shader_info.tex_ds_pool == VK_NULL_HANDLE) {
+		return;
+	}
+	vkFreeDescriptorSets(renderer->device, renderer->shader_info.tex_ds_pool, 1, &ds);
+}
+
+void vk_tex_ds_layout_destroy(struct vk_renderer *renderer) {
+	if (renderer->shader_info.tex_ds_pool != VK_NULL_HANDLE) {
+		vkDestroyDescriptorPool(renderer->device, renderer->shader_info.tex_ds_pool, NULL);
+		renderer->shader_info.tex_ds_pool = VK_NULL_HANDLE;
+	}
+	if (renderer->shader_info.tex_ds_layout != VK_NULL_HANDLE) {
+		vkDestroyDescriptorSetLayout(renderer->device,
+				renderer->shader_info.tex_ds_layout, NULL);
+		renderer->shader_info.tex_ds_layout = VK_NULL_HANDLE;
+	}
+	if (renderer->shader_info.tex_sampler != VK_NULL_HANDLE) {
+		vkDestroySampler(renderer->device, renderer->shader_info.tex_sampler, NULL);
+		renderer->shader_info.tex_sampler = VK_NULL_HANDLE;
+	}
 }
 
 // Shared by all three blur shaders: one sampler set plus a vertex and a

--- a/render/vulkan/shaders/blur1.frag
+++ b/render/vulkan/shaders/blur1.frag
@@ -1,0 +1,27 @@
+#version 450
+
+// Dual-Kawase downsample pass. Port of the GLES2 blur1.frag.
+
+layout(location = 0) in vec2 uv;
+layout(location = 0) out vec4 out_color;
+
+layout(set = 0, binding = 0) uniform sampler2D tex;
+
+// The vertex stage occupies the first 80 bytes (mat4 proj + uv_offset + uv_size).
+// halfpixel is declared first so the vec2 keeps its 8 byte alignment without padding.
+layout(push_constant) uniform UBO {
+	layout(offset = 80) vec2 halfpixel;
+	float radius;
+} data;
+
+void main() {
+	vec2 suv = uv * 2.0;
+
+	vec4 sum = texture(tex, suv) * 4.0;
+	sum += texture(tex, suv - data.halfpixel.xy * data.radius);
+	sum += texture(tex, suv + data.halfpixel.xy * data.radius);
+	sum += texture(tex, suv + vec2(data.halfpixel.x, -data.halfpixel.y) * data.radius);
+	sum += texture(tex, suv - vec2(data.halfpixel.x, -data.halfpixel.y) * data.radius);
+
+	out_color = sum / 8.0;
+}

--- a/render/vulkan/shaders/blur2.frag
+++ b/render/vulkan/shaders/blur2.frag
@@ -1,0 +1,31 @@
+#version 450
+
+// Dual-Kawase upsample pass. Port of the GLES2 blur2.frag.
+
+layout(location = 0) in vec2 uv;
+layout(location = 0) out vec4 out_color;
+
+layout(set = 0, binding = 0) uniform sampler2D tex;
+
+layout(push_constant) uniform UBO {
+	layout(offset = 80) vec2 halfpixel;
+	float radius;
+} data;
+
+void main() {
+	vec2 suv = uv / 2.0;
+	vec2 hp = data.halfpixel;
+	float r = data.radius;
+
+	vec4 sum = texture(tex, suv + vec2(-hp.x * 2.0, 0.0) * r);
+
+	sum += texture(tex, suv + vec2(-hp.x, hp.y) * r) * 2.0;
+	sum += texture(tex, suv + vec2(0.0, hp.y * 2.0) * r);
+	sum += texture(tex, suv + vec2(hp.x, hp.y) * r) * 2.0;
+	sum += texture(tex, suv + vec2(hp.x * 2.0, 0.0) * r);
+	sum += texture(tex, suv + vec2(hp.x, -hp.y) * r) * 2.0;
+	sum += texture(tex, suv + vec2(0.0, -hp.y * 2.0) * r);
+	sum += texture(tex, suv + vec2(-hp.x, -hp.y) * r) * 2.0;
+
+	out_color = sum / 12.0;
+}

--- a/render/vulkan/shaders/blur_effects.frag
+++ b/render/vulkan/shaders/blur_effects.frag
@@ -1,0 +1,61 @@
+#version 450
+
+// Brightness/contrast/saturation/noise applied after the blur chain.
+// Port of the GLES2 blur_effects.frag.
+
+layout(location = 0) in vec2 uv;
+layout(location = 0) out vec4 out_color;
+
+layout(set = 0, binding = 0) uniform sampler2D tex;
+
+layout(push_constant) uniform UBO {
+	layout(offset = 80) float brightness;
+	float contrast;
+	float saturation;
+	float noise;
+} data;
+
+mat4 brightness_matrix() {
+	float b = data.brightness - 1.0;
+	return mat4(1, 0, 0, 0,
+				0, 1, 0, 0,
+				0, 0, 1, 0,
+				b, b, b, 1);
+}
+
+mat4 contrast_matrix() {
+	float t = (1.0 - data.contrast) / 2.0;
+	return mat4(data.contrast, 0, 0, 0,
+				0, data.contrast, 0, 0,
+				0, 0, data.contrast, 0,
+				t, t, t, 1);
+}
+
+mat4 saturation_matrix() {
+	vec3 luminance = vec3(0.3086, 0.6094, 0.0820) * (1.0 - data.saturation);
+	vec3 red = vec3(luminance.x);
+	red.x += data.saturation;
+	vec3 green = vec3(luminance.y);
+	green.y += data.saturation;
+	vec3 blue = vec3(luminance.z);
+	blue.z += data.saturation;
+	return mat4(red, 0,
+				green, 0,
+				blue, 0,
+				0, 0, 0, 1);
+}
+
+float noise_amount(vec2 p) {
+	vec3 p3 = fract(vec3(p.xyx) * 1689.1984);
+	p3 += dot(p3, p3.yzx + 33.33);
+	float hash = fract((p3.x + p3.y) * p3.z);
+	return (mod(hash, 1.0) - 0.5) * data.noise;
+}
+
+void main() {
+	vec4 color = texture(tex, uv);
+	// Do *not* transpose the combined matrix when multiplying
+	color = brightness_matrix() * contrast_matrix() * saturation_matrix() * color;
+	color.xyz += noise_amount(uv);
+	out_color = color;
+}

--- a/render/vulkan/shaders/meson.build
+++ b/render/vulkan/shaders/meson.build
@@ -1,6 +1,9 @@
 vulkan_shaders_src = [
 	'common.vert',
 	'quad.frag',
+	'blur1.frag',
+	'blur2.frag',
+	'blur_effects.frag',
 ]
 
 vulkan_shaders = []


### PR DESCRIPTION
Part of #7. Implements the `Blur → Regular blur` item from #192, on top of that
branch.

Implements blur for the Vulkan renderer, filling in `vk_render_pass_add_blur()`,
`save_blur_region()` and `apply_saved_blur_region()`, which were stubs.

This continues the existing `vulkan-blur` work (shaders, pipelines and the
scenefx-owned sampling path were already in place) and makes blur render.

> [!IMPORTANT]
> **This depends on wlroots changes that are not upstream.** It calls
> `wlr_vk_render_pass_suspend()`, `_resume()`, `_get_blend_image_view()` and
> `_get_blend_image()`, which do not exist in wlroots today. It will not build
> without them. The matching branch is here:
>
> https://github.com/spoloxs/wlroots-vkfx/tree/vulkan-effects
>
> (based on `ammen99/wlroots` `vulkan-effects`, the fork this Vulkan work already
> targets). The code here is complete and reviewable on its own, but it cannot
> build or merge until those wlroots functions have a home — happy to split,
> rebase, or hold this for as long as that takes.

## Why wlroots had to change

Blur has to sample the frame drawn so far. That is impossible from inside the
scene render pass on the two-pass (blending buffer) pathway: geometry and the
blend → output colour transform were two subpasses of a *single* render pass, an
input attachment only permits same-pixel reads (blur needs neighbourhood taps),
and Vulkan forbids ending a render pass while the current subpass is not the
last.

The wlroots branch splits that into two render passes — scene → blend image, then
blend → output carrying the `output_pipe_*` transforms — and exposes
suspend/resume so a consumer can end the scene pass mid-frame, sample the blend
image as a regular texture, and resume with `LOAD_OP_LOAD`.

## How the blur works

Mirrors the GLES2 implementation: N downsample passes (`blur1`), N upsample
passes (`blur2`), then a composite through `blur_effects`.

Render targets live in a new `render/vulkan/effects.c` as plain `VkImage`s owned
by the renderer rather than `wlr_buffer`s, so the chain records into the same
command buffer as the scene and needs no DMA-BUF import or cross-command-buffer
synchronisation.

Their framebuffers are deliberately built against the *scene* render pass:
Vulkan only treats render passes as compatible when they are identical apart
from a short exemption list that does **not** include subpass dependencies, so a
bespoke render pass would make the existing blur pipelines unusable with them.

Because blur only works on the two-pass pathway, it is skipped elsewhere rather
than corrupting the frame. That pathway is also the one colour-managed and HDR
output always take, so blur and HDR compose.

## Notes that cost me time, recorded for the next person

**The composite must use `blur_effects`, not `blur2`.** `blur2` is the upsample
shader and opens with `suv = uv / 2.0`, so using it as a plain blit magnifies the
top-left quarter of the effect image over the whole region — it renders as
ghosted, offset copies of whatever is behind the window.

**The padding repair is what makes damage tracking safe.** Without
`save_blur_region()`/`apply_saved_blur_region()` the blend image still holds the
previous frame's *composited* output wherever nothing was redrawn, so the blur
re-blurs its own result and stair-step banding accumulates. Scoping the chain to
the damage instead just moves the problem: the effect images then have regions
the chain never wrote, which read back as black borders whenever damage is small.

**Copies must be clamped to the image.** `blur_padding_region` is bounded by the
output size, which is not always the render buffer size; a copy running past the
edge is invalid usage and loses the device (`VUID-vkCmdCopyImage-srcOffset-00144`).

`read_to_buffer()` is intentionally left unimplemented here — it is oriented
around `wlr_buffer`s, while the snapshot is a renderer-owned `VkImage`.

## Testing

NVIDIA RTX 5050 (proprietary 610.43.02), Arch, mango 0.15.6, nested Wayland
backend, with `VK_LAYER_KHRONOS_validation` enabled:

- no validation errors across startup, client rendering and teardown
- damage tracking **enabled** (no `WLR_SCENE_DEBUG_DAMAGE=rerender`)
- zero pixel difference between frames captured six seconds apart on an
  otherwise static scene, confirming no blur feedback accumulation
- verified visually against a high-contrast test pattern behind a translucent
  window: smooth blur, correct registration, no black edges or banding

Not yet tested: multi-output, output hotplug/resize under load, non-NVIDIA
drivers, and the `blur_optimized` path (`add_optimized_blur()` is still a stub
returning false).
