### PR TITLE
Fix NVIDIA float precision by switching to GLSL 3.2 ES versioned shaders

### DIFF
--- a/include/render/fx_renderer/fx_renderer.h
+++ b/include/render/fx_renderer/fx_renderer.h
@@ -158,7 +158,7 @@ struct fx_renderer {
 	struct {
 		bool EXT_read_format_bgra;
 		bool KHR_debug;
-		bool OES_egl_image_external;
+		bool OES_egl_image_external_essl3;
 		bool OES_egl_image;
 		bool EXT_texture_type_2_10_10_10_REV;
 		bool OES_texture_half_float_linear;

--- a/render/fx_renderer/fx_pass.c
+++ b/render/fx_renderer/fx_pass.c
@@ -372,8 +372,8 @@ void fx_render_pass_add_texture(struct fx_gles_render_pass *pass,
 		break;
 	case GL_TEXTURE_EXTERNAL_OES:
 		// EGL_EXT_image_dma_buf_import_modifiers requires
-		// GL_OES_EGL_image_external
-		assert(renderer->exts.OES_egl_image_external);
+		// GL_OES_EGL_image_external_essl3
+		assert(renderer->exts.OES_egl_image_external_essl3);
 		shader = use_effects
 			? &renderer->shaders.tex_effects_ext
 			: &renderer->shaders.tex_ext;

--- a/render/fx_renderer/fx_renderer.c
+++ b/render/fx_renderer/fx_renderer.c
@@ -512,9 +512,9 @@ struct wlr_renderer *fx_renderer_create_egl(struct wlr_egl *egl) {
 			"glDebugMessageControlKHR");
 	}
 
-	// TODO: the rest of the gl checks
-	if (check_gl_ext(exts_str, "GL_OES_EGL_image_external")) {
-		renderer->exts.OES_egl_image_external = true;
+	// The GLES 3.0 version of `GL_OES_EGL_image_external`
+	if (check_gl_ext(exts_str, "GL_OES_EGL_image_external_essl3")) {
+		renderer->exts.OES_egl_image_external_essl3 = true;
 		load_gl_proc(&renderer->procs.glEGLImageTargetTexture2DOES,
 			"glEGLImageTargetTexture2DOES");
 	}

--- a/render/fx_renderer/shaders/blur1.frag
+++ b/render/fx_renderer/shaders/blur1.frag
@@ -1,19 +1,23 @@
+#version 320 es
+
 precision mediump float;
 
-varying mediump vec2 v_texcoord;
+in mediump vec2 v_texcoord;
 uniform sampler2D tex;
 
 uniform float radius;
 uniform vec2 halfpixel;
 
+out vec4 fragColor;
+
 void main() {
     vec2 uv = v_texcoord * 2.0;
 
-    vec4 sum = texture2D(tex, uv) * 4.0;
-    sum += texture2D(tex, uv - halfpixel.xy * radius);
-    sum += texture2D(tex, uv + halfpixel.xy * radius);
-    sum += texture2D(tex, uv + vec2(halfpixel.x, -halfpixel.y) * radius);
-    sum += texture2D(tex, uv - vec2(halfpixel.x, -halfpixel.y) * radius);
+    vec4 sum = texture(tex, uv) * 4.0;
+    sum += texture(tex, uv - halfpixel.xy * radius);
+    sum += texture(tex, uv + halfpixel.xy * radius);
+    sum += texture(tex, uv + vec2(halfpixel.x, -halfpixel.y) * radius);
+    sum += texture(tex, uv - vec2(halfpixel.x, -halfpixel.y) * radius);
 
-    gl_FragColor = sum / 8.0;
+    fragColor = sum / 8.0;
 }

--- a/render/fx_renderer/shaders/blur2.frag
+++ b/render/fx_renderer/shaders/blur2.frag
@@ -1,23 +1,27 @@
+#version 320 es
+
 precision mediump float;
 
-varying mediump vec2 v_texcoord;
+in mediump vec2 v_texcoord;
 uniform sampler2D tex;
 
 uniform float radius;
 uniform vec2 halfpixel;
 
+out vec4 fragColor;
+
 void main() {
     vec2 uv = v_texcoord / 2.0;
 
-    vec4 sum = texture2D(tex, uv + vec2(-halfpixel.x * 2.0, 0.0) * radius);
+    vec4 sum = texture(tex, uv + vec2(-halfpixel.x * 2.0, 0.0) * radius);
 
-    sum += texture2D(tex, uv + vec2(-halfpixel.x, halfpixel.y) * radius) * 2.0;
-    sum += texture2D(tex, uv + vec2(0.0, halfpixel.y * 2.0) * radius);
-    sum += texture2D(tex, uv + vec2(halfpixel.x, halfpixel.y) * radius) * 2.0;
-    sum += texture2D(tex, uv + vec2(halfpixel.x * 2.0, 0.0) * radius);
-    sum += texture2D(tex, uv + vec2(halfpixel.x, -halfpixel.y) * radius) * 2.0;
-    sum += texture2D(tex, uv + vec2(0.0, -halfpixel.y * 2.0) * radius);
-    sum += texture2D(tex, uv + vec2(-halfpixel.x, -halfpixel.y) * radius) * 2.0;
+    sum += texture(tex, uv + vec2(-halfpixel.x, halfpixel.y) * radius) * 2.0;
+    sum += texture(tex, uv + vec2(0.0, halfpixel.y * 2.0) * radius);
+    sum += texture(tex, uv + vec2(halfpixel.x, halfpixel.y) * radius) * 2.0;
+    sum += texture(tex, uv + vec2(halfpixel.x * 2.0, 0.0) * radius);
+    sum += texture(tex, uv + vec2(halfpixel.x, -halfpixel.y) * radius) * 2.0;
+    sum += texture(tex, uv + vec2(0.0, -halfpixel.y * 2.0) * radius);
+    sum += texture(tex, uv + vec2(-halfpixel.x, -halfpixel.y) * radius) * 2.0;
 
-    gl_FragColor = sum / 12.0;
+    fragColor = sum / 12.0;
 }

--- a/render/fx_renderer/shaders/blur_effects.frag
+++ b/render/fx_renderer/shaders/blur_effects.frag
@@ -1,16 +1,16 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
-precision highp float;
-#else
-precision mediump float;
-#endif
+#version 320 es
 
-varying vec2 v_texcoord;
+precision highp float;
+
+in vec2 v_texcoord;
 uniform sampler2D tex;
 
 uniform float brightness;
 uniform float contrast;
 uniform float saturation;
 uniform float noise;
+
+out vec4 fragColor;
 
 mat4 brightnessMatrix() {
 	float b = brightness - 1.0;
@@ -50,9 +50,9 @@ float noiseAmount(vec2 p) {
 }
 
 void main() {
-	vec4 color = texture2D(tex, v_texcoord);
+	vec4 color = texture(tex, v_texcoord);
 	// Do *not* transpose the combined matrix when multiplying
 	color = brightnessMatrix() * contrastMatrix() * saturationMatrix() * color;
 	color.xyz += noiseAmount(v_texcoord);
-	gl_FragColor = color;
+	fragColor = color;
 }

--- a/render/fx_renderer/shaders/box_shadow.frag
+++ b/render/fx_renderer/shaders/box_shadow.frag
@@ -1,13 +1,10 @@
 // Writeup: https://madebyevan.com/shaders/fast-rounded-rectangle-shadows/
+#version 320 es
 
-#ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
-#else
-precision mediump float;
-#endif
 
-varying vec4 v_color;
-varying vec2 v_texcoord;
+in vec4 v_color;
+in vec2 v_texcoord;
 
 uniform vec2 position;
 uniform vec2 size;
@@ -19,6 +16,8 @@ uniform float clip_radius_top_left;
 uniform float clip_radius_top_right;
 uniform float clip_radius_bottom_left;
 uniform float clip_radius_bottom_right;
+
+out vec4 fragColor;
 
 float gaussian(float x, float sigma) {
     const float pi = 3.141592653589793;
@@ -87,5 +86,5 @@ void main() {
         clip_radius_bottom_right
     );
 
-    gl_FragColor = vec4(v_color.rgb, shadow_alpha) * clip_corner_alpha;
+    fragColor = vec4(v_color.rgb, shadow_alpha) * clip_corner_alpha;
 }

--- a/render/fx_renderer/shaders/common.vert
+++ b/render/fx_renderer/shaders/common.vert
@@ -1,9 +1,11 @@
+#version 320 es
+
 uniform mat3 proj;
 uniform vec4 color;
 uniform mat3 tex_proj;
-attribute vec2 pos;
-varying vec4 v_color;
-varying vec2 v_texcoord;
+in vec2 pos;
+out vec4 v_color;
+out vec2 v_texcoord;
 
 void main() {
 	vec3 pos3 = vec3(pos, 1.0);

--- a/render/fx_renderer/shaders/quad.frag
+++ b/render/fx_renderer/shaders/quad.frag
@@ -1,17 +1,15 @@
+#version 320 es
+
 #define EFFECTS %d
 
 #if !defined(EFFECTS)
 #error "Missing shader preamble"
 #endif
 
-#ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
-#else
-precision mediump float;
-#endif
 
-varying vec4 v_color;
-varying vec2 v_texcoord;
+in vec4 v_color;
+in vec2 v_texcoord;
 
 #if EFFECTS
 uniform vec2 clip_size;
@@ -21,6 +19,8 @@ uniform float clip_radius_top_right;
 uniform float clip_radius_bottom_left;
 uniform float clip_radius_bottom_right;
 #endif
+
+out vec4 fragColor;
 
 float corner_alpha(vec2 size, vec2 position, bool is_cutout,
 		float radius_tl, float radius_tr, float radius_bl, float radius_br);
@@ -38,8 +38,8 @@ void main() {
 		clip_radius_bottom_right
 	);
 
-	gl_FragColor = v_color * clip_corner_alpha;
+	fragColor = v_color * clip_corner_alpha;
 #else
-	gl_FragColor = v_color;
+	fragColor = v_color;
 #endif
 }

--- a/render/fx_renderer/shaders/quad_grad.frag
+++ b/render/fx_renderer/shaders/quad_grad.frag
@@ -1,13 +1,11 @@
+#version 320 es
+
 #define LEN %d
 
-#ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
-#else
-precision mediump float;
-#endif
 
-varying vec4 v_color;
-varying vec2 v_texcoord;
+in vec4 v_color;
+in vec2 v_texcoord;
 
 uniform vec4 colors[LEN];
 uniform vec2 size;
@@ -18,8 +16,10 @@ uniform bool linear;
 uniform bool blend;
 uniform int count;
 
+out vec4 fragColor;
+
 vec4 gradient(vec4 colors[LEN], int count, vec2 size, vec2 grad_box, vec2 origin, float degree, bool linear, bool blend);
 
 void main(){
-	gl_FragColor = gradient(colors, count, size, grad_box, origin, degree, linear, blend);
+	fragColor = gradient(colors, count, size, grad_box, origin, degree, linear, blend);
 }

--- a/render/fx_renderer/shaders/quad_grad_round.frag
+++ b/render/fx_renderer/shaders/quad_grad_round.frag
@@ -1,13 +1,11 @@
+#version 320 es
+
 #define LEN %d
 
-#ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
-#else
-precision mediump float;
-#endif
 
-varying vec4 v_color;
-varying vec2 v_texcoord;
+in vec4 v_color;
+in vec2 v_texcoord;
 
 uniform vec2 size;
 uniform vec2 position;
@@ -25,6 +23,8 @@ uniform vec2 origin;
 uniform bool linear;
 uniform bool blend;
 uniform int count;
+
+out vec4 fragColor;
 
 vec4 gradient(vec4 colors[LEN], int count, vec2 size, vec2 grad_box, vec2 origin, float degree, bool linear, bool blend);
 
@@ -44,5 +44,5 @@ void main() {
 	);
 	float rect_alpha = v_color.a * quad_corner_alpha;
 
-	gl_FragColor = mix(vec4(0.0), gradient(colors, count, size, grad_box, origin, degree, linear, blend), rect_alpha);
+	fragColor = mix(vec4(0.0), gradient(colors, count, size, grad_box, origin, degree, linear, blend), rect_alpha);
 }

--- a/render/fx_renderer/shaders/quad_round.frag
+++ b/render/fx_renderer/shaders/quad_round.frag
@@ -1,11 +1,9 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
-precision highp float;
-#else
-precision mediump float;
-#endif
+#version 320 es
 
-varying vec4 v_color;
-varying vec2 v_texcoord;
+precision highp float;
+
+in vec4 v_color;
+in vec2 v_texcoord;
 
 uniform vec2 size;
 uniform vec2 position;
@@ -20,6 +18,8 @@ uniform float clip_radius_top_left;
 uniform float clip_radius_top_right;
 uniform float clip_radius_bottom_left;
 uniform float clip_radius_bottom_right;
+
+out vec4 fragColor;
 
 float corner_alpha(vec2 size, vec2 position, bool is_cutout,
 		float radius_tl, float radius_tr, float radius_bl, float radius_br);
@@ -46,5 +46,5 @@ void main() {
 		clip_radius_bottom_right
 	);
 
-	gl_FragColor = v_color * quad_corner_alpha * clip_corner_alpha;
+	fragColor = v_color * quad_corner_alpha * clip_corner_alpha;
 }

--- a/render/fx_renderer/shaders/tex.frag
+++ b/render/fx_renderer/shaders/tex.frag
@@ -1,3 +1,5 @@
+#version 320 es
+
 #define SOURCE %d
 #define EFFECTS %d
 
@@ -10,16 +12,12 @@
 #endif
 
 #if SOURCE == SOURCE_TEXTURE_EXTERNAL
-#extension GL_OES_EGL_image_external : require
+#extension GL_OES_EGL_image_external_essl3 : require
 #endif
 
-#ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
-#else
-precision mediump float;
-#endif
 
-varying vec2 v_texcoord;
+in vec2 v_texcoord;
 
 #if SOURCE == SOURCE_TEXTURE_EXTERNAL
 uniform samplerExternalOES tex;
@@ -47,11 +45,13 @@ uniform float clip_radius_bottom_right;
 
 uniform bool discard_transparent;
 
+out vec4 fragColor;
+
 vec4 sample_texture() {
 #if SOURCE == SOURCE_TEXTURE_RGBA || SOURCE == SOURCE_TEXTURE_EXTERNAL
-	return texture2D(tex, v_texcoord);
+	return texture(tex, v_texcoord);
 #elif SOURCE == SOURCE_TEXTURE_RGBX
-	return vec4(texture2D(tex, v_texcoord).rgb, 1.0);
+	return vec4(texture(tex, v_texcoord).rgb, 1.0);
 #endif
 }
 
@@ -83,12 +83,12 @@ void main() {
 		clip_radius_bottom_right
 	);
 
-	gl_FragColor = sample_texture() * alpha * quad_corner_alpha * clip_corner_alpha;
+	fragColor = sample_texture() * alpha * quad_corner_alpha * clip_corner_alpha;
 #else
-	gl_FragColor = sample_texture() * alpha;
+	fragColor = sample_texture() * alpha;
 #endif
 
-	if (discard_transparent && gl_FragColor.a == 0.0) {
+	if (discard_transparent && fragColor.a == 0.0) {
 		discard;
 	}
 }


### PR DESCRIPTION
Supersedes: #177 

This fixes the rounded corner artifacts on high-resolution monitors on NVIDIA hardware. The NVIDIA drivers currently don't advertise support for `highp` floats in GLES 2. This is fixed by setting our shader version to GLSL 3.2, as 3.2 requires support for high-precision floats.