### PR TITLE
fix(shadow): handle zero blur sigma

### DIFF
--- a/render/fx_renderer/fx_pass.c
+++ b/render/fx_renderer/fx_pass.c
@@ -773,6 +773,24 @@ void fx_render_pass_add_box_shadow(struct fx_gles_render_pass *pass,
 
 	struct wlr_box box = options->box;
 	assert(box.width > 0 && box.height > 0);
+	if (options->blur_sigma <= 0.0f) {
+		fx_render_pass_add_rounded_rect(pass,
+				&(struct fx_render_rounded_rect_options){
+			.base = {
+				.box = box,
+				.color = options->color,
+				.clip = options->clip,
+			},
+			.corners = {
+				.top_left = options->corner_radius,
+				.top_right = options->corner_radius,
+				.bottom_right = options->corner_radius,
+				.bottom_left = options->corner_radius,
+			},
+			.clipped_region = options->clipped_region,
+		});
+		return;
+	}
 
 	pixman_region32_t clip_region;
 	if (options->clip) {
@@ -801,8 +819,7 @@ void fx_render_pass_add_box_shadow(struct fx_gles_render_pass *pass,
 	TRACY_ZONE_TEXT_f("\tBlur Sigma: %f", options->blur_sigma);
 	push_fx_debug(renderer);
 
-	// blending will practically always be needed (unless we have a madman
-	// who uses opaque shadows with zero sigma), so just enable it
+	// Blurred edges require blending, so just enable it
 	setup_blending(WLR_RENDER_BLEND_MODE_PREMULTIPLIED);
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 

--- a/render/fx_renderer/shaders/box_shadow.frag
+++ b/render/fx_renderer/shaders/box_shadow.frag
@@ -70,11 +70,24 @@ float corner_alpha(vec2 size, vec2 position, bool is_cutout,
         float radius_tl, float radius_tr, float radius_bl, float radius_br);
 
 void main() {
-    float shadow_alpha = v_color.a * roundedBoxShadow(
-            position + blur_sigma,
-            position + size - blur_sigma,
-            gl_FragCoord.xy, blur_sigma * 0.5,
-            corner_radius);
+    float shadow_alpha;
+    if (blur_sigma <= 0.0) {
+        shadow_alpha = v_color.a * corner_alpha(
+            size - 1.0,
+            position + 0.5,
+            false,
+            corner_radius,
+            corner_radius,
+            corner_radius,
+            corner_radius
+        );
+    } else {
+        shadow_alpha = v_color.a * roundedBoxShadow(
+                position + blur_sigma,
+                position + size - blur_sigma,
+                gl_FragCoord.xy, blur_sigma * 0.5,
+                corner_radius);
+    }
 
     // Clipping
     float clip_corner_alpha = corner_alpha(

--- a/render/fx_renderer/shaders/box_shadow.frag
+++ b/render/fx_renderer/shaders/box_shadow.frag
@@ -70,24 +70,11 @@ float corner_alpha(vec2 size, vec2 position, bool is_cutout,
         float radius_tl, float radius_tr, float radius_bl, float radius_br);
 
 void main() {
-    float shadow_alpha;
-    if (blur_sigma <= 0.0) {
-        shadow_alpha = v_color.a * corner_alpha(
-            size - 1.0,
-            position + 0.5,
-            false,
-            corner_radius,
-            corner_radius,
-            corner_radius,
-            corner_radius
-        );
-    } else {
-        shadow_alpha = v_color.a * roundedBoxShadow(
-                position + blur_sigma,
-                position + size - blur_sigma,
-                gl_FragCoord.xy, blur_sigma * 0.5,
-                corner_radius);
-    }
+    float shadow_alpha = v_color.a * roundedBoxShadow(
+            position + blur_sigma,
+            position + size - blur_sigma,
+            gl_FragCoord.xy, blur_sigma * 0.5,
+            corner_radius);
 
     // Clipping
     float clip_corner_alpha = corner_alpha(


### PR DESCRIPTION
## What this fixes

The box-shadow shader evaluates Gaussian functions that divide by the blur
sigma. A sigma of zero therefore produces undefined values and can make a
zero-blur shadow disappear.

Use the existing rounded-corner mask when the sigma is non positive, while
keeping the current Gaussian path for positive values. This also preserves the
configured corner radius for sharp shadows.

## Verification

- `nix build --no-link`
- visual inspection

A visual check with a zero-sigma rounded shadow is still recommended, especially since I'm unsure if this is intended behavior? If so feel free to close it.