### PR TITLE
fix(scene): detect full blur damage by region coverage

### DIFF
--- a/types/scene/wlr_scene.c
+++ b/types/scene/wlr_scene.c
@@ -3314,11 +3314,17 @@ bool wlr_scene_output_build_state(struct wlr_scene_output *scene_output,
 		pixman_region32_init(&original_damage);
 		pixman_region32_copy(&original_damage, &render_data.damage);
 
-		// Only compensate for blur artifacts when the damage doesn't span
+		// Only compensate for blur artifacts when the damage doesn't cover
 		// the whole output
+		const pixman_box32_t output_box = {
+			.x1 = 0,
+			.y1 = 0,
+			.x2 = buffer->width,
+			.y2 = buffer->height,
+		};
 		const bool full_damage =
-			original_damage.extents.x2 - original_damage.extents.x1 >= output->width
-			&& original_damage.extents.y2 - original_damage.extents.y1 >= output->height;
+			pixman_region32_contains_rectangle(&original_damage, &output_box) ==
+			PIXMAN_REGION_IN;
 
 		// The extra region we copy and paste onto the framebuffer after render
 		// for artifact removal


### PR DESCRIPTION
## What this fixes

A damage region can contain separate rectangles whose combined extents span the
output without actually covering it. The current extents check classifies that
case as full damage and skips blur damage compensation.

Use `pixman_region32_contains_rectangle()` to check whether the damage region
really covers the complete output buffer.

## Verification

- `nix build --no-link`
- Confirmed that two sparse opposite-corner rectangles fail the old full-damage
  predicate and remain partial with the new predicate.
- Confirmed that a rectangle covering the complete buffer is still classified
  as full damage.