### PR TITLE
chore: overall hardening of the repository

### DIFF
--- a/examples/scene-graph.c
+++ b/examples/scene-graph.c
@@ -75,6 +75,10 @@ static void server_handle_new_output(struct wl_listener *listener, void *data) {
 	wlr_output_init_render(wlr_output, server->allocator, server->renderer);
 
 	struct output *output = calloc(1, sizeof(*output));
+	if (output == NULL) {
+		wlr_log(WLR_ERROR, "failed to allocate output");
+		return;
+	}
 	output->wlr = wlr_output;
 	output->server = server;
 	output->frame.notify = output_handle_frame;
@@ -124,6 +128,10 @@ static void server_handle_new_surface(struct wl_listener *listener,
 	server->surface_offset += 50;
 
 	struct surface *surface = calloc(1, sizeof(*surface));
+	if (surface == NULL) {
+		wlr_log(WLR_ERROR, "failed to allocate surface");
+		return;
+	}
 	surface->wlr = wlr_surface;
 	surface->commit.notify = surface_handle_commit;
 	wl_signal_add(&wlr_surface->events.commit, &surface->commit);

--- a/include/scenefx/types/fx/blur_data.h
+++ b/include/scenefx/types/fx/blur_data.h
@@ -13,6 +13,32 @@ struct blur_data {
 	float saturation;
 };
 
+// Sane, documented bounds for blur_data.num_passes/radius. blur_data_calc_size()
+// feeds pow(2, num_passes + 1) into an int cast, so num_passes needs to stay
+// low enough that the result can't leave int range.
+#define BLUR_DATA_MAX_NUM_PASSES 10
+#define BLUR_DATA_MAX_RADIUS 100
+
+// Clamp num_passes/radius to [0, BLUR_DATA_MAX_*], same pattern as
+// corner_radius_clamp() in clipped_region.h.
+static __always_inline int blur_data_clamp_num_passes(int num_passes) {
+	if (num_passes < 0) {
+		return 0;
+	} else if (num_passes > BLUR_DATA_MAX_NUM_PASSES) {
+		return BLUR_DATA_MAX_NUM_PASSES;
+	}
+	return num_passes;
+}
+
+static __always_inline float blur_data_clamp_radius(float radius) {
+	if (radius < 0) {
+		return 0;
+	} else if (radius > BLUR_DATA_MAX_RADIUS) {
+		return BLUR_DATA_MAX_RADIUS;
+	}
+	return radius;
+}
+
 struct blur_data blur_data_get_default(void);
 
 bool is_scene_blur_enabled(struct blur_data *blur_data);

--- a/include/scenefx/types/fx/blur_data.h
+++ b/include/scenefx/types/fx/blur_data.h
@@ -13,14 +13,10 @@ struct blur_data {
 	float saturation;
 };
 
-// Sane, documented bounds for blur_data.num_passes/radius. blur_data_calc_size()
-// feeds pow(2, num_passes + 1) into an int cast, so num_passes needs to stay
-// low enough that the result can't leave int range.
+// num_passes needs to stay low enough that blur_data_calc_size() can't leave int range
 #define BLUR_DATA_MAX_NUM_PASSES 10
 #define BLUR_DATA_MAX_RADIUS 100
 
-// Clamp num_passes/radius to [0, BLUR_DATA_MAX_*], same pattern as
-// corner_radius_clamp() in clipped_region.h.
 static __always_inline int blur_data_clamp_num_passes(int num_passes) {
 	if (num_passes < 0) {
 		return 0;

--- a/render/color.c
+++ b/render/color.c
@@ -42,7 +42,9 @@ struct wlr_color_transform *wlr_color_transform_init_linear_to_inverse_eotf(
 
 struct wlr_color_transform *wlr_color_transform_init_lut_3x1d(size_t dim,
 		const uint16_t *r, const uint16_t *g, const uint16_t *b) {
-	uint16_t *lut_3x1d = malloc(3 * dim * sizeof(lut_3x1d[0]));
+	// calloc() gets the standard's built-in nmemb * size overflow check for
+	// free; a raw malloc() with manual multiplication here does not.
+	uint16_t *lut_3x1d = calloc(3 * dim, sizeof(lut_3x1d[0]));
 	if (lut_3x1d == NULL) {
 		return NULL;
 	}

--- a/render/egl.c
+++ b/render/egl.c
@@ -439,6 +439,12 @@ static bool egl_init(struct wlr_egl *egl, EGLenum platform,
 		wlr_log(WLR_DEBUG, "Created EGL context using OpenGL ES 2.0");
 	} else {
 		wlr_log(WLR_ERROR, "Failed to create EGL context using OpenGL ES 2.0");
+		// Mirror the egl_init_display() failure branch above: the display
+		// is already fully initialized at this point, so it needs the same
+		// teardown on this failure path or it leaks.
+		if (egl->exts.KHR_display_reference) {
+			eglTerminate(egl->display);
+		}
 		return false;
 	}
 
@@ -639,6 +645,12 @@ struct wlr_egl *wlr_egl_create_with_context(EGLDisplay display,
 	}
 
 	if (!egl_init_display(egl, display, true)) {
+		// Same shape as egl_init()'s call site: egl_init_display() failing
+		// here still means eglInitialize() already succeeded, so the
+		// display needs tearing down or it leaks.
+		if (egl->exts.KHR_display_reference) {
+			eglTerminate(egl->display);
+		}
 		free(egl);
 		return NULL;
 	}

--- a/render/fx_renderer/fx_pass.c
+++ b/render/fx_renderer/fx_pass.c
@@ -993,9 +993,7 @@ static struct fx_framebuffer *get_main_buffer_blur(struct fx_gles_render_pass *p
 	if (fx_options->blur_strength <= 0 || !is_scene_blur_enabled(&blur_data)) {
 		return NULL;
 	}
-	// Write the adjusted value back through the pointer the caller already
-	// gave us, rather than pointing fx_options->blur_data at this stack
-	// frame: that pointer would dangle as soon as this function returns.
+	// avoid dangling pointer to this stack frame
 	*fx_options->blur_data = blur_data;
 	fx_options->tex_options.base.transform = WL_OUTPUT_TRANSFORM_NORMAL;
 

--- a/render/fx_renderer/fx_pass.c
+++ b/render/fx_renderer/fx_pass.c
@@ -993,7 +993,10 @@ static struct fx_framebuffer *get_main_buffer_blur(struct fx_gles_render_pass *p
 	if (fx_options->blur_strength <= 0 || !is_scene_blur_enabled(&blur_data)) {
 		return NULL;
 	}
-	fx_options->blur_data = &blur_data;
+	// Write the adjusted value back through the pointer the caller already
+	// gave us, rather than pointing fx_options->blur_data at this stack
+	// frame: that pointer would dangle as soon as this function returns.
+	*fx_options->blur_data = blur_data;
 	fx_options->tex_options.base.transform = WL_OUTPUT_TRANSFORM_NORMAL;
 
 	pixman_region32_t damage;

--- a/tinywl/tinywl.c
+++ b/tinywl/tinywl.c
@@ -270,6 +270,10 @@ static void server_new_keyboard(struct tinywl_server *server,
 	struct wlr_keyboard *wlr_keyboard = wlr_keyboard_from_input_device(device);
 
 	struct tinywl_keyboard *keyboard = calloc(1, sizeof(*keyboard));
+	if (keyboard == NULL) {
+		wlr_log(WLR_ERROR, "failed to allocate keyboard");
+		return;
+	}
 	keyboard->server = server;
 	keyboard->wlr_keyboard = wlr_keyboard;
 
@@ -756,6 +760,10 @@ static void server_new_output(struct wl_listener *listener, void *data) {
 
 	/* Allocates and configures our state for this output */
 	struct tinywl_output *output = calloc(1, sizeof(*output));
+	if (output == NULL) {
+		wlr_log(WLR_ERROR, "failed to allocate output");
+		return;
+	}
 	output->wlr_output = wlr_output;
 	output->server = server;
 
@@ -955,6 +963,10 @@ static void server_new_xdg_toplevel(struct wl_listener *listener, void *data) {
 
 	/* Allocate a tinywl_toplevel for this surface */
 	struct tinywl_toplevel *toplevel = calloc(1, sizeof(*toplevel));
+	if (toplevel == NULL) {
+		wlr_log(WLR_ERROR, "failed to allocate toplevel");
+		return;
+	}
 	toplevel->server = server;
 	toplevel->xdg_toplevel = xdg_toplevel;
 	toplevel->scene_tree = wlr_scene_tree_create(toplevel->server->layers.toplevel_layer);
@@ -1039,6 +1051,10 @@ static void server_new_xdg_popup(struct wl_listener *listener, void *data) {
 	struct wlr_xdg_popup *xdg_popup = data;
 
 	struct tinywl_popup *popup = calloc(1, sizeof(*popup));
+	if (popup == NULL) {
+		wlr_log(WLR_ERROR, "failed to allocate popup");
+		return;
+	}
 	popup->xdg_popup = xdg_popup;
 
 	/* We must add xdg popups to the scene graph so they get rendered. The

--- a/types/fx/blur_data.c
+++ b/types/fx/blur_data.c
@@ -23,9 +23,6 @@ bool blur_data_should_parameters_blur_effects(struct blur_data *blur_data) {
 }
 
 int blur_data_calc_size(struct blur_data *blur_data) {
-	// Converting an out-of-range double to int is undefined behavior, not
-	// defined wraparound, so clamp num_passes/radius here too rather than
-	// trusting the setter-level clamp to always run first.
 	int num_passes = blur_data_clamp_num_passes(blur_data->num_passes);
 	float radius = blur_data_clamp_radius(blur_data->radius);
 	return pow(2, num_passes + 1) * radius;

--- a/types/fx/blur_data.c
+++ b/types/fx/blur_data.c
@@ -23,7 +23,12 @@ bool blur_data_should_parameters_blur_effects(struct blur_data *blur_data) {
 }
 
 int blur_data_calc_size(struct blur_data *blur_data) {
-	return pow(2, blur_data->num_passes + 1) * blur_data->radius;
+	// Converting an out-of-range double to int is undefined behavior, not
+	// defined wraparound, so clamp num_passes/radius here too rather than
+	// trusting the setter-level clamp to always run first.
+	int num_passes = blur_data_clamp_num_passes(blur_data->num_passes);
+	float radius = blur_data_clamp_radius(blur_data->radius);
+	return pow(2, num_passes + 1) * radius;
 }
 
 static float lerp(float a, float b, float f) {

--- a/types/scene/wlr_scene.c
+++ b/types/scene/wlr_scene.c
@@ -1329,8 +1329,7 @@ void wlr_scene_optimized_blur_set_size(struct wlr_scene_optimized_blur *blur_nod
 }
 
 void wlr_scene_optimized_blur_mark_dirty(struct wlr_scene_optimized_blur *blur_node) {
-	// Skip re-rendering the optimized blur if there's no blur node or it's
-	// disabled
+	// Skip re-rendering the optimized blur if the blur node is disabled
 	if (!blur_node || !blur_node->node.enabled) {
 		return;
 	}

--- a/types/scene/wlr_scene.c
+++ b/types/scene/wlr_scene.c
@@ -1209,6 +1209,9 @@ void wlr_scene_blur_set_clipped_region(struct wlr_scene_blur *blur,
 
 void wlr_scene_set_blur_data(struct wlr_scene *scene, int num_passes,
 		int radius, float noise, float brightness, float contrast, float saturation) {
+	num_passes = blur_data_clamp_num_passes(num_passes);
+	radius = blur_data_clamp_radius(radius);
+
 	struct blur_data *buff_data = &scene->blur_data;
 	if (buff_data->num_passes == num_passes
 			&& buff_data->radius == radius
@@ -1231,6 +1234,8 @@ void wlr_scene_set_blur_data(struct wlr_scene *scene, int num_passes,
 }
 
 void wlr_scene_set_blur_num_passes(struct wlr_scene *scene, int num_passes) {
+	num_passes = blur_data_clamp_num_passes(num_passes);
+
 	struct blur_data *buff_data = &scene->blur_data;
 	if (buff_data->num_passes == num_passes) {
 		return;
@@ -1241,6 +1246,8 @@ void wlr_scene_set_blur_num_passes(struct wlr_scene *scene, int num_passes) {
 }
 
 void wlr_scene_set_blur_radius(struct wlr_scene *scene, int radius) {
+	radius = blur_data_clamp_radius(radius);
+
 	struct blur_data *buff_data = &scene->blur_data;
 	if (buff_data->radius == radius) {
 		return;
@@ -1322,8 +1329,9 @@ void wlr_scene_optimized_blur_set_size(struct wlr_scene_optimized_blur *blur_nod
 }
 
 void wlr_scene_optimized_blur_mark_dirty(struct wlr_scene_optimized_blur *blur_node) {
-	// Skip re-rendering the optimized blur if the blur node is disabled
-	if (blur_node && !blur_node->node.enabled) {
+	// Skip re-rendering the optimized blur if there's no blur node or it's
+	// disabled
+	if (!blur_node || !blur_node->node.enabled) {
 		return;
 	}
 

--- a/util/array.c
+++ b/util/array.c
@@ -1,9 +1,17 @@
 #include "util/array.h"
 #include <assert.h>
+#include <stdint.h>
 #include <string.h>
 
 void array_remove_at(struct wl_array *arr, size_t offset, size_t size) {
-	assert(arr->size >= offset + size);
+	// offset + size can overflow, and callers can be built without asserts
+	// (NDEBUG), so this needs to be a real check rather than assert-only:
+	// letting a bad range through turns the memmove length below into a
+	// huge underflowed value.
+	if (offset > arr->size || size > arr->size - offset) {
+		assert(0 && "array_remove_at: out-of-bounds range");
+		return;
+	}
 
 	char *data = arr->data;
 	memmove(&data[offset], &data[offset + size], arr->size - offset - size);
@@ -22,7 +30,13 @@ bool array_realloc(struct wl_array *arr, size_t size) {
 		alloc = 16;
 	}
 
+	// Checked doubling: bail before a doubling that would overflow alloc
+	// instead of wrapping it to a too-small value and under-allocating
+	// below.
 	while (alloc < size) {
+		if (alloc > SIZE_MAX / 2) {
+			return false;
+		}
 		alloc *= 2;
 	}
 


### PR DESCRIPTION
### I decided to take a look at the repository and harden it. Here's what i found:
- array_realloc/array_remove_at: fix overflow in doubling and bounds check
- color.c: malloc -> calloc for LUT alloc (overflow check)
- blur setters: clamp num_passes/radius, also clamped in blur_data_calc_size
- optimized_blur_mark_dirty: fix inverted null check
- get_main_buffer_blur: fix dangling pointer (was pointing at a stack local)
- egl.c: fix EGLDisplay leak on two failure paths
- scene-graph.c/tinywl.c: null-check calloc at 6 sites

I have fixed all of these bugs in the hardening branch and am now creating this PR since I consider my work done. It builds clean.